### PR TITLE
schematrons: Move url prefix parameter to a separate file

### DIFF
--- a/schematrons/dynamic/change-notices.sch
+++ b/schematrons/dynamic/change-notices.sch
@@ -3,13 +3,11 @@
 <!-- This file contains schematron rules to enforce that certain values in a Change Notice are the 
 	 same as those in the parent notice (the notice that is subject to the change). -->
 
-<!-- URL prefix of the service to fetch a notice. -->
-<let name="urlPrefix" value="'http://localhost:8080/notices/'"/>
-
 <!-- Reference to the parent notice. -->
 <let name="parentNoticeId" value="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Changes/efbc:ChangedNoticeIdentifier/fn:normalize-space(text())"/>
 
-<!-- Function that fetches a notice. -->
+<!-- Function that fetches a notice based on its identifier.
+	 The value of $urlPrefix is defined in config.sch. -->
 <let name="getParentNotice" value="function($id) { fn:doc(concat($urlPrefix, $id)) }"/>
 
 <!-- XML document of the parent notice. -->

--- a/schematrons/dynamic/config.sch
+++ b/schematrons/dynamic/config.sch
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- URL prefix of the service to fetch a notice.
+	 The value must be between single quotes.
+	 The notice identifier will be appended, to build the URL used to fetch the corresponding notice XML. -->
+<let xmlns="http://purl.oclc.org/dsdl/schematron" name="urlPrefix" value="'http://localhost:8080/notices/'"/>

--- a/schematrons/dynamic/entry.sch
+++ b/schematrons/dynamic/entry.sch
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!--File generated from metadata database version 0.5.172 created on the 2022-07-28T11:31:53.-->
+<!--File generated from metadata database version 0.5.177 created on the 2022-07-29T15:12:01.-->
 <schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
 	<ns prefix="xs" uri="http://www.w3.org/2001/XMLSchema" />
 	<ns prefix="sch" uri="http://purl.oclc.org/dsdl/schematron" />
@@ -18,6 +18,7 @@
 	
 	<let name="noticeSubType" value="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeSubType/cbc:SubTypeCode/text()"/>
 	
+	<include href="config.sch"/>
 	<include href="stage-1-preliminary.sch"/>
 	<include href="stage-1.sch"/>
 	<include href="stage-2.sch"/>


### PR DESCRIPTION
Move the definition of the "urlPrefix" variable in a separate
"config.sch" file.

This allows changing the value by just overwriting this file.

Other ways of referencing an external file do not work, and config.sch
must have the indicated structure.