### PR TITLE
cn_81 EstimatedOverallContractAmount to 0

### DIFF
--- a/examples/notices/cn_81.xml
+++ b/examples/notices/cn_81.xml
@@ -116,7 +116,7 @@
 		This requirement is subject to approval.</cbc:Description>
 		<cbc:ProcurementTypeCode listName="contract-nature">services</cbc:ProcurementTypeCode>
 		<cac:RequestedTenderTotal>
-			<cbc:EstimatedOverallContractAmount currencyID="EUR">0000000000</cbc:EstimatedOverallContractAmount>
+			<cbc:EstimatedOverallContractAmount currencyID="EUR">0</cbc:EstimatedOverallContractAmount>
 		</cac:RequestedTenderTotal>
 		<cac:MainCommodityClassification>
 			<cbc:ItemClassificationCode listName="cpv">80512000</cbc:ItemClassificationCode>


### PR DESCRIPTION
Normalized examples/notices/cn_81 EstimatedOverallContractAmount to 0

We are using examples to test our generated code from XSD files by parsing and serializing the result again to compare it produces the same result. However in example cn_81 EstimatedOverallContractAmount is defined as 0 with multiple zeros and because zero is 0 it cannot be reproduced automatically. 