### PR TITLE
examples: Fix incorrect values in "test" attributes (TEDEFO-1695)

### DIFF
--- a/examples/reports/INVALID_can_24_empty.svrl
+++ b/examples/reports/INVALID_can_24_empty.svrl
@@ -186,7 +186,7 @@ cac:ContractingPartyType/cbc:PartyTypeCode[@listName='buyer-legal-type']</svrl:d
    <svrl:failed-assert id="BR-BT-00004-0052"
                        location="/ContractAwardNotice/cbc:ContractFolderID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^[a-f0-9]8-[a-f0-9]4-4[a-f0-9]3-[89ab][a-f0-9]3-[a-f0-9]12$')">
+                       test="matches(normalize-space(.),'^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$')">
       <svrl:text>rule|text|BR-BT-00004-0052</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cbc:IssueDate"/>

--- a/examples/reports/INVALID_can_24_stage-1.svrl
+++ b/examples/reports/INVALID_can_24_stage-1.svrl
@@ -527,28 +527,28 @@ cbc:Description</svrl:diagnostic-reference>
    <svrl:failed-assert id="BR-OPT-00321-0052"
                        location="/ContractAwardNotice/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^TEN-\d4$')">
+                       test="matches(normalize-space(.),'^TEN-\d{4}$')">
       <svrl:text>rule|text|BR-OPT-00321-0052</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/cbc:ID"/>
    <svrl:failed-assert id="BR-OPT-00316-0052"
                        location="/ContractAwardNotice/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^CON-\d4$')">
+                       test="matches(normalize-space(.),'^CON-\d{4}$')">
       <svrl:text>rule|text|BR-OPT-00316-0052</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/cbc:ID"/>
    <svrl:failed-assert id="BR-OPT-00210-0052"
                        location="/ContractAwardNotice/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^TPA-\d4$')">
+                       test="matches(normalize-space(.),'^TPA-\d{4}$')">
       <svrl:text>rule|text|BR-OPT-00210-0052</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/efac:Tenderer/cbc:ID"/>
    <svrl:failed-assert id="BR-OPT-00300-0203"
                        location="/ContractAwardNotice/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/efac:Tenderer/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^ORG-\d4$')">
+                       test="matches(normalize-space(.),'^ORG-\d{4}$')">
       <svrl:text>rule|text|BR-OPT-00300-0203</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeSubType/cbc:SubTypeCode"/>
@@ -556,14 +556,14 @@ cbc:Description</svrl:diagnostic-reference>
    <svrl:failed-assert id="BR-OPT-00200-0051"
                        location="/ContractAwardNotice/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:PartyIdentification/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^ORG-\d4$')">
+                       test="matches(normalize-space(.),'^ORG-\d{4}$')">
       <svrl:text>rule|text|BR-OPT-00200-0051</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cbc:ContractFolderID"/>
    <svrl:failed-assert id="BR-BT-00004-0052"
                        location="/ContractAwardNotice/cbc:ContractFolderID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^[a-f0-9]8-[a-f0-9]4-4[a-f0-9]3-[89ab][a-f0-9]3-[a-f0-9]12$')">
+                       test="matches(normalize-space(.),'^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$')">
       <svrl:text>rule|text|BR-BT-00004-0052</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cbc:IssueDate"/>
@@ -588,7 +588,7 @@ cbc:Description</svrl:diagnostic-reference>
    <svrl:failed-assert id="BR-BT-00137-0155"
                        location="/ContractAwardNotice/cac:ProcurementProjectLot/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^LOT-\d4$')">
+                       test="matches(normalize-space(.),'^LOT-\d{4}$')">
       <svrl:text>rule|text|BR-BT-00137-0155</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:MainCommodityClassification/cbc:ItemClassificationCode"/>

--- a/examples/reports/INVALID_can_24_stage-2.svrl
+++ b/examples/reports/INVALID_can_24_stage-2.svrl
@@ -493,7 +493,7 @@
    <svrl:failed-assert id="BR-OPT-00315-0051"
                        location="/ContractAwardNotice/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:SettledContract/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^CON-\d4$')">
+                       test="matches(normalize-space(.),'^CON-\d{4}$')">
       <svrl:text>rule|text|BR-OPT-00315-0051</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:TenderLot/cbc:ID"/>
@@ -501,42 +501,42 @@
    <svrl:failed-assert id="BR-OPT-00321-0052"
                        location="/ContractAwardNotice/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^TEN-\d4$')">
+                       test="matches(normalize-space(.),'^TEN-\d{4}$')">
       <svrl:text>rule|text|BR-OPT-00321-0052</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:TenderingParty/cbc:ID"/>
    <svrl:failed-assert id="BR-OPT-00310-0052"
                        location="/ContractAwardNotice/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:TenderingParty/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^TPA-\d4$')">
+                       test="matches(normalize-space(.),'^TPA-\d{4}$')">
       <svrl:text>rule|text|BR-OPT-00310-0052</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/cbc:ID"/>
    <svrl:failed-assert id="BR-OPT-00316-0052"
                        location="/ContractAwardNotice/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^CON-\d4$')">
+                       test="matches(normalize-space(.),'^CON-\d{4}$')">
       <svrl:text>rule|text|BR-OPT-00316-0052</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:LotTender/cbc:ID"/>
    <svrl:failed-assert id="BR-BT-03202-0051"
                        location="/ContractAwardNotice/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:LotTender/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^TEN-\d4$')">
+                       test="matches(normalize-space(.),'^TEN-\d{4}$')">
       <svrl:text>rule|text|BR-BT-03202-0051</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/cbc:ID"/>
    <svrl:failed-assert id="BR-OPT-00210-0052"
                        location="/ContractAwardNotice/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^TPA-\d4$')">
+                       test="matches(normalize-space(.),'^TPA-\d{4}$')">
       <svrl:text>rule|text|BR-OPT-00210-0052</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/efac:Tenderer/cbc:ID"/>
    <svrl:failed-assert id="BR-OPT-00300-0203"
                        location="/ContractAwardNotice/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/efac:Tenderer/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^ORG-\d4$')">
+                       test="matches(normalize-space(.),'^ORG-\d{4}$')">
       <svrl:text>rule|text|BR-OPT-00300-0203</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeSubType/cbc:SubTypeCode"/>
@@ -544,7 +544,7 @@
    <svrl:failed-assert id="BR-OPT-00200-0051"
                        location="/ContractAwardNotice/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:PartyIdentification/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^ORG-\d4$')">
+                       test="matches(normalize-space(.),'^ORG-\d{4}$')">
       <svrl:text>rule|text|BR-OPT-00200-0051</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:PartyName/cbc:Name"/>
@@ -567,7 +567,7 @@
    <svrl:failed-assert id="BR-BT-00506-0052"
                        location="/ContractAwardNotice/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:Contact/cbc:ElectronicMail"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^[a-zA-Z0-9][a-zA-Z0-9._%+-]*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]2 63$')">
+                       test="matches(normalize-space(.),'^[a-zA-Z0-9][a-zA-Z0-9._%+-]*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,63}$')">
       <svrl:text>rule|text|BR-BT-00506-0052</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cbc:UBLVersionID"/>
@@ -576,14 +576,14 @@
    <svrl:failed-assert id="BR-BT-00701-0052"
                        location="/ContractAwardNotice/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^[a-f0-9]8-[a-f0-9]4-4[a-f0-9]3-[89ab][a-f0-9]3-[a-f0-9]12$')">
+                       test="matches(normalize-space(.),'^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$')">
       <svrl:text>rule|text|BR-BT-00701-0052</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cbc:ContractFolderID"/>
    <svrl:failed-assert id="BR-BT-00004-0052"
                        location="/ContractAwardNotice/cbc:ContractFolderID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^[a-f0-9]8-[a-f0-9]4-4[a-f0-9]3-[89ab][a-f0-9]3-[a-f0-9]12$')">
+                       test="matches(normalize-space(.),'^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$')">
       <svrl:text>rule|text|BR-BT-00004-0052</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cbc:IssueDate"/>
@@ -623,7 +623,7 @@
    <svrl:failed-assert id="BR-BT-00137-0155"
                        location="/ContractAwardNotice/cac:ProcurementProjectLot/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^LOT-\d4$')">
+                       test="matches(normalize-space(.),'^LOT-\d{4}$')">
       <svrl:text>rule|text|BR-BT-00137-0155</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cbc:FundingProgramCode[@listName='eu-funded']"/>
@@ -646,7 +646,7 @@
    <svrl:failed-assert id="BR-OPT-00301-1216"
                        location="/ContractAwardNotice/cac:ProcurementProjectLot/cac:TenderingTerms/cac:AppealTerms/cac:AppealReceiverParty/cac:PartyIdentification/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^(ORG|TPO)-\d4$')">
+                       test="matches(normalize-space(.),'^(ORG|TPO)-\d{4}$')">
       <svrl:text>rule|text|BR-OPT-00301-1216</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:ContractingSystem/cbc:ContractingSystemTypeCode[@listName='framework-agreement']"/>

--- a/examples/reports/INVALID_cn_24_empty.svrl
+++ b/examples/reports/INVALID_cn_24_empty.svrl
@@ -238,7 +238,7 @@ cac:MainCommodityClassification/cbc:ItemClassificationCode</svrl:diagnostic-refe
    <svrl:failed-assert id="BR-BT-00004-0052"
                        location="/ContractNotice/cbc:ContractFolderID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^[a-f0-9]8-[a-f0-9]4-4[a-f0-9]3-[89ab][a-f0-9]3-[a-f0-9]12$')">
+                       test="matches(normalize-space(.),'^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$')">
       <svrl:text>rule|text|BR-BT-00004-0052</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cbc:RegulatoryDomain"/>

--- a/examples/reports/INVALID_cn_24_stage-1.svrl
+++ b/examples/reports/INVALID_cn_24_stage-1.svrl
@@ -596,14 +596,14 @@ cbc:Description</svrl:diagnostic-reference>
    <svrl:failed-assert id="BR-OPT-00200-0051"
                        location="/ContractNotice/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:PartyIdentification/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^ORG-\d4$')">
+                       test="matches(normalize-space(.),'^ORG-\d{4}$')">
       <svrl:text>rule|text|BR-OPT-00200-0051</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cbc:ContractFolderID"/>
    <svrl:failed-assert id="BR-BT-00004-0052"
                        location="/ContractNotice/cbc:ContractFolderID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^[a-f0-9]8-[a-f0-9]4-4[a-f0-9]3-[89ab][a-f0-9]3-[a-f0-9]12$')">
+                       test="matches(normalize-space(.),'^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$')">
       <svrl:text>rule|text|BR-BT-00004-0052</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cbc:RegulatoryDomain"/>
@@ -627,7 +627,7 @@ cbc:Description</svrl:diagnostic-reference>
    <svrl:failed-assert id="BR-BT-00137-0155"
                        location="/ContractNotice/cac:ProcurementProjectLot/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^LOT-\d4$')">
+                       test="matches(normalize-space(.),'^LOT-\d{4}$')">
       <svrl:text>rule|text|BR-BT-00137-0155</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:MainCommodityClassification/cbc:ItemClassificationCode"/>

--- a/examples/reports/INVALID_cn_24_stage-2.svrl
+++ b/examples/reports/INVALID_cn_24_stage-2.svrl
@@ -510,7 +510,7 @@
    <svrl:failed-assert id="BR-OPT-00200-0051"
                        location="/ContractNotice/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:PartyIdentification/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^ORG-\d4$')">
+                       test="matches(normalize-space(.),'^ORG-\d{4}$')">
       <svrl:text>rule|text|BR-OPT-00200-0051</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:PartyName/cbc:Name"/>
@@ -533,7 +533,7 @@
    <svrl:failed-assert id="BR-BT-00506-0052"
                        location="/ContractNotice/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:Contact/cbc:ElectronicMail"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^[a-zA-Z0-9][a-zA-Z0-9._%+-]*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]2 63$')">
+                       test="matches(normalize-space(.),'^[a-zA-Z0-9][a-zA-Z0-9._%+-]*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,63}$')">
       <svrl:text>rule|text|BR-BT-00506-0052</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cbc:UBLVersionID"/>
@@ -542,14 +542,14 @@
    <svrl:failed-assert id="BR-BT-00701-0052"
                        location="/ContractNotice/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^[a-f0-9]8-[a-f0-9]4-4[a-f0-9]3-[89ab][a-f0-9]3-[a-f0-9]12$')">
+                       test="matches(normalize-space(.),'^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$')">
       <svrl:text>rule|text|BR-BT-00701-0052</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cbc:ContractFolderID"/>
    <svrl:failed-assert id="BR-BT-00004-0052"
                        location="/ContractNotice/cbc:ContractFolderID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^[a-f0-9]8-[a-f0-9]4-4[a-f0-9]3-[89ab][a-f0-9]3-[a-f0-9]12$')">
+                       test="matches(normalize-space(.),'^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$')">
       <svrl:text>rule|text|BR-BT-00004-0052</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cbc:IssueDate"/>
@@ -615,7 +615,7 @@
    <svrl:failed-assert id="BR-BT-00137-0155"
                        location="/ContractNotice/cac:ProcurementProjectLot/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^LOT-\d4$')">
+                       test="matches(normalize-space(.),'^LOT-\d{4}$')">
       <svrl:text>rule|text|BR-BT-00137-0155</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:SelectionCriteria/cbc:CriterionTypeCode[@listName='selection-criterion']"/>
@@ -678,7 +678,7 @@
    <svrl:failed-assert id="BR-OPT-00301-1218"
                        location="/ContractNotice/cac:ProcurementProjectLot/cac:TenderingTerms/cac:TenderRecipientParty/cac:PartyIdentification/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^(ORG|TPO)-\d4$')">
+                       test="matches(normalize-space(.),'^(ORG|TPO)-\d{4}$')">
       <svrl:text>rule|text|BR-OPT-00301-1218</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AppealTerms/cac:PresentationPeriod/cbc:Description"/>
@@ -686,7 +686,7 @@
    <svrl:failed-assert id="BR-OPT-00301-1216"
                        location="/ContractNotice/cac:ProcurementProjectLot/cac:TenderingTerms/cac:AppealTerms/cac:AppealReceiverParty/cac:PartyIdentification/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^(ORG|TPO)-\d4$')">
+                       test="matches(normalize-space(.),'^(ORG|TPO)-\d{4}$')">
       <svrl:text>rule|text|BR-OPT-00301-1216</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:Language/cbc:ID"/>

--- a/examples/reports/INVALID_pin-buyer_24_stage-1.svrl
+++ b/examples/reports/INVALID_pin-buyer_24_stage-1.svrl
@@ -275,7 +275,7 @@ cbc:Description</svrl:diagnostic-reference>
    <svrl:failed-assert id="BR-OPT-00200-0051"
                        location="/PriorInformationNotice/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:PartyIdentification/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^ORG-\d4$')">
+                       test="matches(normalize-space(.),'^ORG-\d{4}$')">
       <svrl:text>rule|text|BR-OPT-00200-0051</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cbc:IssueDate"/>

--- a/examples/reports/INVALID_pin-only_24_stage-1.svrl
+++ b/examples/reports/INVALID_pin-only_24_stage-1.svrl
@@ -330,7 +330,7 @@ cbc:Description</svrl:diagnostic-reference>
    <svrl:failed-assert id="BR-OPT-00200-0051"
                        location="/PriorInformationNotice/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:PartyIdentification/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^ORG-\d4$')">
+                       test="matches(normalize-space(.),'^ORG-\d{4}$')">
       <svrl:text>rule|text|BR-OPT-00200-0051</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cbc:IssueDate"/>
@@ -361,7 +361,7 @@ cbc:Description</svrl:diagnostic-reference>
    <svrl:failed-assert id="BR-BT-00137-0154"
                        location="/PriorInformationNotice/cac:ProcurementProjectLot/cbc:ID"
                        role="ERROR"
-                       test="matches(normalize-space(.),'^PAR-\d4$')">
+                       test="matches(normalize-space(.),'^PAR-\d{4}$')">
       <svrl:text>rule|text|BR-BT-00137-0154</svrl:text>
    </svrl:failed-assert>
    <svrl:fired-rule context="/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:MainCommodityClassification/cbc:ItemClassificationCode"/>


### PR DESCRIPTION
Due to a bug in the tool used to produce them, the validation reports were missing curly braces '{' and '}' in the test attribute for failed asserts.
The Schematron rule was properly executed, it's just the value in the report that was incorrect.

Fixes issue #251.