### PR TITLE
pom: Enable reproducible builds (TEDEFO-1730)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.outputTimestamp>1</project.build.outputTimestamp>
   </properties>
 
   <build>
@@ -78,6 +79,10 @@
           <configuration>
             <createChecksum>true</createChecksum>
           </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.3.0</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Use latest version of maven-jar-plugin, which supports reproducible builds, and set the "project.build.outputTimestamp" property. The value of the property does not matter, it just ensures the entries in the JAR archive have always the same timestamp.