### PR TITLE
Prepare for release of SDK 1.5.1

### DIFF
--- a/.ted/tedweb/search-metadata.json
+++ b/.ted/tedweb/search-metadata.json
@@ -128,7 +128,7 @@
 		"comment": "Languages in which tenders may be submitted"
 	},
 	"TI-Title": {
-		"efx": "{ND-Root} ${value-union(/BT-21-Procedure, /OPP-121-Business)}",
+		"efx": "{ND-Root} ${/BT-21-Procedure}",
 		"comment": "(TI) Title (Title of the document)"
 	},
 	"TI-CPV": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# SDK 1.5.1 Release Notes
+
+This release includes several corrections:
+
+* Correct notice type definition for subtype 14, add and correct a few groups for other subtypes.
+* Add missing English texts for 2 codes in the "innovative-acquisition" codelist.
+
+A comprehensive list of changes between SDK 1.5.0 and SDK 1.5.1 can seen at <https://github.com/OP-TED/eForms-SDK/compare/1.5.0...1.5.1>
+
+The documentation for the SDK is available at <https://docs.ted.europa.eu>. The source for this documentation is maintained in the [eforms-docs](https://github.com/OP-TED/eforms-docs) repository.
+
+
 # SDK 1.5.0 Release Notes
 
 This release of the SDK does not contain any backwards incompatible changes: software that was able to use version 1.4.0 should also be able to use this version.

--- a/codelists/innovative-acquisition.gc
+++ b/codelists/innovative-acquisition.gc
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--File generated from metadata database version 1.5.0 created on the 2022-12-14T11:00-->
+<!--File generated from metadata database version 1.5.12 created on the 2023-01-12T09:49:36-->
 <gc:CodeList xmlns:gc="http://docs.oasis-open.org/codelist/ns/genericode/1.0/">
    <Identification>
       <ShortName>InnovativeAcquisition</ShortName>
@@ -525,7 +525,7 @@
             <SimpleValue>proc-innov</SimpleValue>
          </Value>
          <Value ColumnRef="Name">
-            <SimpleValue/>
+            <SimpleValue>The procured works, supplies, or services entail process innovation</SimpleValue>
          </Value>
          <Value ColumnRef="bul_label">
             <SimpleValue>Строителните дейности, доставките или услугите, които са предмет на поръчката, са свързани с иновация на процесите.</SimpleValue>
@@ -541,6 +541,9 @@
          </Value>
          <Value ColumnRef="ell_label">
             <SimpleValue>Τα έργα, οι προμήθειες ή οι υπηρεσίες που αποτελούν αντικείμενο της σύμβασης συνεπάγονται καινοτομία ως προς τη διεργασία.</SimpleValue>
+         </Value>
+         <Value ColumnRef="eng_label">
+            <SimpleValue>The procured works, supplies, or services entail process innovation.</SimpleValue>
          </Value>
          <Value ColumnRef="spa_label">
             <SimpleValue>Las obras, los suministros o los servicios contratados implican la innovación de procesos.</SimpleValue>
@@ -602,7 +605,7 @@
             <SimpleValue>prod-innov</SimpleValue>
          </Value>
          <Value ColumnRef="Name">
-            <SimpleValue/>
+            <SimpleValue>The procured works, supplies, or services entail product innovation</SimpleValue>
          </Value>
          <Value ColumnRef="bul_label">
             <SimpleValue>Строителните дейности, доставките или услугите, които са предмет на поръчката, са свързани с продуктови иновации.</SimpleValue>
@@ -618,6 +621,9 @@
          </Value>
          <Value ColumnRef="ell_label">
             <SimpleValue>Τα έργα, οι προμήθειες ή οι υπηρεσίες που αποτελούν αντικείμενο της σύμβασης συνεπάγονται καινοτομία ως προς το προϊόν.</SimpleValue>
+         </Value>
+         <Value ColumnRef="eng_label">
+            <SimpleValue>The procured works, supplies, or services entail product innovation.</SimpleValue>
          </Value>
          <Value ColumnRef="spa_label">
             <SimpleValue>Las obras, los suministros o los servicios contratados implican la innovación de productos.</SimpleValue>

--- a/fields/fields.json
+++ b/fields/fields.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "eforms-sdk-1.5.0",
+  "sdkVersion" : "eforms-sdk-1.5.1",
   "metadataDatabase" : {
     "version" : "1.5.0",
     "createdOn" : "2022-12-14T11:00:00"

--- a/notice-types/10.json
+++ b/notice-types/10.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "10",
   "metadata" : [ {
@@ -1321,17 +1321,25 @@
           "description" : "Tenderer Legal Form Description",
           "_label" : "field|name|BT-76-Lot"
         }, {
-          "id" : "BT-771-Lot",
-          "contentType" : "field",
-          "displayType" : "COMBOBOX",
-          "description" : "Late Tenderer Information",
-          "_label" : "field|name|BT-771-Lot"
-        }, {
-          "id" : "BT-772-Lot",
-          "contentType" : "field",
-          "displayType" : "TEXTAREA",
-          "description" : "Late Tenderer Information Description",
-          "_label" : "field|name|BT-772-Lot"
+          "id" : "GR-LateTendererInformation",
+          "contentType" : "group",
+          "nodeId" : "ND-LateTendererInformation",
+          "displayType" : "GROUP",
+          "description" : "Information about late provision of information by the tenderer (possibility and description of the information)",
+          "_label" : "group|name|ND-LateTendererInformation",
+          "content" : [ {
+            "id" : "BT-771-Lot",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "Late Tenderer Information",
+            "_label" : "field|name|BT-771-Lot"
+          }, {
+            "id" : "BT-772-Lot",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Late Tenderer Information Description",
+            "_label" : "field|name|BT-772-Lot"
+          } ]
         }, {
           "id" : "GR-ReservedParticipation",
           "contentType" : "group",

--- a/notice-types/11.json
+++ b/notice-types/11.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "11",
   "metadata" : [ {
@@ -1329,17 +1329,25 @@
           "description" : "Tenderer Legal Form Description",
           "_label" : "field|name|BT-76-Lot"
         }, {
-          "id" : "BT-771-Lot",
-          "contentType" : "field",
-          "displayType" : "COMBOBOX",
-          "description" : "Late Tenderer Information",
-          "_label" : "field|name|BT-771-Lot"
-        }, {
-          "id" : "BT-772-Lot",
-          "contentType" : "field",
-          "displayType" : "TEXTAREA",
-          "description" : "Late Tenderer Information Description",
-          "_label" : "field|name|BT-772-Lot"
+          "id" : "GR-LateTendererInformation",
+          "contentType" : "group",
+          "nodeId" : "ND-LateTendererInformation",
+          "displayType" : "GROUP",
+          "description" : "Information about late provision of information by the tenderer (possibility and description of the information)",
+          "_label" : "group|name|ND-LateTendererInformation",
+          "content" : [ {
+            "id" : "BT-771-Lot",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "Late Tenderer Information",
+            "_label" : "field|name|BT-771-Lot"
+          }, {
+            "id" : "BT-772-Lot",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Late Tenderer Information Description",
+            "_label" : "field|name|BT-772-Lot"
+          } ]
         }, {
           "id" : "GR-ReservedParticipation",
           "contentType" : "group",

--- a/notice-types/12.json
+++ b/notice-types/12.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "12",
   "metadata" : [ {
@@ -1310,17 +1310,25 @@
           "description" : "Tenderer Legal Form Description",
           "_label" : "field|name|BT-76-Lot"
         }, {
-          "id" : "BT-771-Lot",
-          "contentType" : "field",
-          "displayType" : "COMBOBOX",
-          "description" : "Late Tenderer Information",
-          "_label" : "field|name|BT-771-Lot"
-        }, {
-          "id" : "BT-772-Lot",
-          "contentType" : "field",
-          "displayType" : "TEXTAREA",
-          "description" : "Late Tenderer Information Description",
-          "_label" : "field|name|BT-772-Lot"
+          "id" : "GR-LateTendererInformation",
+          "contentType" : "group",
+          "nodeId" : "ND-LateTendererInformation",
+          "displayType" : "GROUP",
+          "description" : "Information about late provision of information by the tenderer (possibility and description of the information)",
+          "_label" : "group|name|ND-LateTendererInformation",
+          "content" : [ {
+            "id" : "BT-771-Lot",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "Late Tenderer Information",
+            "_label" : "field|name|BT-771-Lot"
+          }, {
+            "id" : "BT-772-Lot",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Late Tenderer Information Description",
+            "_label" : "field|name|BT-772-Lot"
+          } ]
         }, {
           "id" : "GR-ReservedParticipation",
           "contentType" : "group",

--- a/notice-types/13.json
+++ b/notice-types/13.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "13",
   "metadata" : [ {
@@ -1316,17 +1316,25 @@
           "description" : "Tenderer Legal Form Description",
           "_label" : "field|name|BT-76-Lot"
         }, {
-          "id" : "BT-771-Lot",
-          "contentType" : "field",
-          "displayType" : "COMBOBOX",
-          "description" : "Late Tenderer Information",
-          "_label" : "field|name|BT-771-Lot"
-        }, {
-          "id" : "BT-772-Lot",
-          "contentType" : "field",
-          "displayType" : "TEXTAREA",
-          "description" : "Late Tenderer Information Description",
-          "_label" : "field|name|BT-772-Lot"
+          "id" : "GR-LateTendererInformation",
+          "contentType" : "group",
+          "nodeId" : "ND-LateTendererInformation",
+          "displayType" : "GROUP",
+          "description" : "Information about late provision of information by the tenderer (possibility and description of the information)",
+          "_label" : "group|name|ND-LateTendererInformation",
+          "content" : [ {
+            "id" : "BT-771-Lot",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "Late Tenderer Information",
+            "_label" : "field|name|BT-771-Lot"
+          }, {
+            "id" : "BT-772-Lot",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Late Tenderer Information Description",
+            "_label" : "field|name|BT-772-Lot"
+          } ]
         }, {
           "id" : "GR-ReservedParticipation",
           "contentType" : "group",

--- a/notice-types/14.json
+++ b/notice-types/14.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "14",
   "metadata" : [ {
@@ -1197,17 +1197,25 @@
           "description" : "Tenderer Legal Form Description",
           "_label" : "field|name|BT-76-Lot"
         }, {
-          "id" : "BT-771-Lot",
-          "contentType" : "field",
-          "displayType" : "COMBOBOX",
-          "description" : "Late Tenderer Information",
-          "_label" : "field|name|BT-771-Lot"
-        }, {
-          "id" : "BT-772-Lot",
-          "contentType" : "field",
-          "displayType" : "TEXTAREA",
-          "description" : "Late Tenderer Information Description",
-          "_label" : "field|name|BT-772-Lot"
+          "id" : "GR-LateTendererInformation",
+          "contentType" : "group",
+          "nodeId" : "ND-LateTendererInformation",
+          "displayType" : "GROUP",
+          "description" : "Information about late provision of information by the tenderer (possibility and description of the information)",
+          "_label" : "group|name|ND-LateTendererInformation",
+          "content" : [ {
+            "id" : "BT-771-Lot",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "Late Tenderer Information",
+            "_label" : "field|name|BT-771-Lot"
+          }, {
+            "id" : "BT-772-Lot",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Late Tenderer Information Description",
+            "_label" : "field|name|BT-772-Lot"
+          } ]
         }, {
           "id" : "GR-ReservedParticipation",
           "contentType" : "group",
@@ -1314,390 +1322,953 @@
           "_label" : "field|name|BT-732-Lot"
         } ]
       }, {
-        "id" : "BT-801-Lot",
-        "contentType" : "field",
-        "displayType" : "COMBOBOX",
-        "description" : "Non Disclosure Agreement",
-        "_label" : "field|name|BT-801-Lot"
+        "id" : "GR-Nda",
+        "contentType" : "group",
+        "nodeId" : "ND-NDA",
+        "displayType" : "GROUP",
+        "description" : "Description of the NDA",
+        "_label" : "group|name|ND-NDA",
+        "content" : [ {
+          "id" : "BT-801-Lot",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Non Disclosure Agreement",
+          "_label" : "field|name|BT-801-Lot"
+        }, {
+          "id" : "BT-802-Lot",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Non Disclosure Agreement Description",
+          "_label" : "field|name|BT-802-Lot"
+        } ]
       }, {
-        "id" : "BT-802-Lot",
-        "contentType" : "field",
-        "displayType" : "TEXTAREA",
-        "description" : "Non Disclosure Agreement Description",
-        "_label" : "field|name|BT-802-Lot"
-      } ]
-    }, {
-      "id" : "GR-Lot-ElectronicSignatureRequired",
-      "contentType" : "group",
-      "displayType" : "GROUP",
-      "description" : "Electronic Signature Required",
-      "_label" : "group|name|GR-Lot-ElectronicSignatureRequired",
-      "content" : [ {
-        "id" : "BT-744-Lot",
-        "contentType" : "field",
-        "displayType" : "COMBOBOX",
-        "description" : "Submission Electronic Signature",
-        "_label" : "field|name|BT-744-Lot"
-      } ]
-    }, {
-      "id" : "GR-Lot-PostAwardProcess",
-      "contentType" : "group",
-      "displayType" : "GROUP",
-      "description" : "Post Award Process",
-      "_label" : "group|name|GR-Lot-PostAwardProcess",
-      "content" : [ {
-        "id" : "BT-92-Lot",
-        "contentType" : "field",
-        "displayType" : "RADIO",
-        "description" : "Electronic Ordering",
-        "_label" : "field|name|BT-92-Lot"
+        "id" : "GR-Lot-ElectronicSignatureRequired",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Electronic Signature Required",
+        "_label" : "group|name|GR-Lot-ElectronicSignatureRequired",
+        "content" : [ {
+          "id" : "BT-744-Lot",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Submission Electronic Signature",
+          "_label" : "field|name|BT-744-Lot"
+        } ]
       }, {
-        "id" : "BT-93-Lot",
-        "contentType" : "field",
-        "displayType" : "RADIO",
-        "description" : "Electronic Payment",
-        "_label" : "field|name|BT-93-Lot"
+        "id" : "GR-Lot-PostAwardProcess",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Post Award Process",
+        "_label" : "group|name|GR-Lot-PostAwardProcess",
+        "content" : [ {
+          "id" : "BT-92-Lot",
+          "contentType" : "field",
+          "displayType" : "RADIO",
+          "description" : "Electronic Ordering",
+          "_label" : "field|name|BT-92-Lot"
+        }, {
+          "id" : "BT-93-Lot",
+          "contentType" : "field",
+          "displayType" : "RADIO",
+          "description" : "Electronic Payment",
+          "_label" : "field|name|BT-93-Lot"
+        } ]
+      }, {
+        "id" : "GR-Lot-FinancialTerms",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Financial Terms",
+        "_label" : "group|name|GR-Lot-FinancialTerms",
+        "content" : [ {
+          "id" : "BT-77-Lot",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Terms Financial",
+          "_label" : "field|name|BT-77-Lot"
+        } ]
+      }, {
+        "id" : "GR-Lot-TenderReceipt",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Tender Recipient Organisation",
+        "_label" : "group|name|GR-Lot-TenderReceipt",
+        "content" : [ {
+          "id" : "OPT-301-Lot-TenderReceipt",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Tender Recipient Technical Identifier Reference",
+          "_label" : "field|name|OPT-301-Lot-TenderReceipt",
+          "_idSchemes" : [ "ORG", "TPO" ]
+        } ]
+      }, {
+        "id" : "GR-Lot-TenderEval",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Tender Evaluation Organisation",
+        "_label" : "group|name|GR-Lot-TenderEval",
+        "content" : [ {
+          "id" : "OPT-301-Lot-TenderEval",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Tender Evaluator Technical Identifier Reference",
+          "_label" : "field|name|OPT-301-Lot-TenderEval",
+          "_idSchemes" : [ "ORG", "TPO" ]
+        } ]
       } ]
     }, {
-      "id" : "GR-Lot-FinancialTerms",
+      "id" : "GR-Lot-SubmissionInfo",
       "contentType" : "group",
-      "displayType" : "GROUP",
-      "description" : "Financial Terms",
-      "_label" : "group|name|GR-Lot-FinancialTerms",
+      "displayType" : "SECTION",
+      "description" : "Submission Info",
+      "_label" : "group|name|GR-Lot-SubmissionInfo",
       "content" : [ {
-        "id" : "BT-77-Lot",
-        "contentType" : "field",
-        "displayType" : "TEXTAREA",
-        "description" : "Terms Financial",
-        "_label" : "field|name|BT-77-Lot"
+        "id" : "GR-Lot-Procedure",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Procedure",
+        "_label" : "group|name|GR-Lot-Procedure",
+        "content" : [ {
+          "id" : "BT-634-Lot",
+          "contentType" : "field",
+          "displayType" : "RADIO",
+          "description" : "Procurement Relaunch",
+          "_label" : "field|name|BT-634-Lot"
+        } ]
+      }, {
+        "id" : "GR-Lot-Deadlines1",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Deadlines I",
+        "_label" : "group|name|GR-Lot-Deadlines1",
+        "content" : [ {
+          "id" : "BT-130-Lot",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Dispatch Invitation Tender",
+          "_label" : "field|name|BT-130-Lot"
+        }, {
+          "id" : "BT-631-Lot",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Dispatch Invitation Interest",
+          "_label" : "field|name|BT-631-Lot"
+        }, {
+          "id" : "BT-13(d)-Lot",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Additional Information Deadline",
+          "_label" : "field|name|BT-13(d)-Lot"
+        }, {
+          "id" : "BT-13(t)-Lot",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Additional Information Deadline",
+          "_label" : "field|name|BT-13(t)-Lot"
+        } ]
+      }, {
+        "id" : "GR-Lot-Deadlines2",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Deadlines II",
+        "_label" : "group|name|GR-Lot-Deadlines2",
+        "content" : [ {
+          "id" : "BT-630(d)-Lot",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Deadline Receipt Expressions",
+          "_label" : "field|name|BT-630(d)-Lot"
+        }, {
+          "id" : "BT-630(t)-Lot",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Deadline Receipt Expressions",
+          "_label" : "field|name|BT-630(t)-Lot"
+        } ]
+      }, {
+        "id" : "GR-Lot-Submission Language",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Submission Language",
+        "_label" : "group|name|GR-Lot-Submission Language",
+        "content" : [ {
+          "id" : "BT-97-Lot",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Submission Language",
+          "_label" : "field|name|BT-97-Lot",
+          "_repeatable" : true
+        } ]
+      }, {
+        "id" : "GR-Lot-FinancialGuarantee",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Financial Guarantee",
+        "_label" : "group|name|GR-Lot-FinancialGuarantee",
+        "content" : [ {
+          "id" : "BT-751-Lot",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Guarantee Required",
+          "_label" : "field|name|BT-751-Lot"
+        }, {
+          "id" : "BT-75-Lot",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Guarantee Required Description",
+          "_label" : "field|name|BT-75-Lot"
+        } ]
+      }, {
+        "id" : "GR-Lot-SubmissionMethod",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Submission Method",
+        "_label" : "group|name|GR-Lot-SubmissionMethod",
+        "content" : [ {
+          "id" : "BT-17-Lot",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "SubmissionElectronic",
+          "_label" : "field|name|BT-17-Lot"
+        }, {
+          "id" : "BT-18-Lot",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Submission URL",
+          "_label" : "field|name|BT-18-Lot"
+        }, {
+          "id" : "BT-19-Lot",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Submission Nonelectronic Justification",
+          "_label" : "field|name|BT-19-Lot"
+        }, {
+          "id" : "BT-745-Lot",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Submission Nonelectronic Description",
+          "_label" : "field|name|BT-745-Lot"
+        } ]
+      }, {
+        "id" : "GR-Lot-ProcurementDocuments",
+        "contentType" : "group",
+        "nodeId" : "ND-LotProcurementDocument",
+        "displayType" : "GROUP",
+        "description" : "Procurement Document information for a Lot, independent from the restricted aspect",
+        "_label" : "group|name|ND-LotProcurementDocument",
+        "_repeatable" : true,
+        "content" : [ {
+          "id" : "BT-14-Lot",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Documents Restricted",
+          "_label" : "field|name|BT-14-Lot"
+        }, {
+          "id" : "OPT-050-Lot",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Document Status",
+          "_label" : "field|name|OPT-050-Lot"
+        }, {
+          "id" : "BT-707-Lot",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Documents Restricted Justification",
+          "_label" : "field|name|BT-707-Lot"
+        }, {
+          "id" : "BT-708-Lot",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Documents Official Language",
+          "_label" : "field|name|BT-708-Lot"
+        }, {
+          "id" : "BT-737-Lot",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Documents Unofficial Language",
+          "_label" : "field|name|BT-737-Lot"
+        }, {
+          "id" : "BT-15-Lot",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Documents URL",
+          "_label" : "field|name|BT-15-Lot"
+        }, {
+          "id" : "BT-615-Lot",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Documents Restricted URL",
+          "_label" : "field|name|BT-615-Lot"
+        }, {
+          "id" : "OPT-140-Lot",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Procurement Documents ID",
+          "_label" : "field|name|OPT-140-Lot"
+        } ]
+      }, {
+        "id" : "GR-Lot-SubmissionTool",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Submission Tool",
+        "_label" : "group|name|GR-Lot-SubmissionTool",
+        "content" : [ {
+          "id" : "BT-632-Lot",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Tool Name",
+          "_label" : "field|name|BT-632-Lot"
+        }, {
+          "id" : "BT-124-Lot",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Tool Atypical URL",
+          "_label" : "field|name|BT-124-Lot"
+        } ]
+      }, {
+        "id" : "GR-Lot-AddInfo",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Additional Information Providing Organisation",
+        "_label" : "group|name|GR-Lot-AddInfo",
+        "content" : [ {
+          "id" : "OPT-301-Lot-AddInfo",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Additional Info Provider Technical Identifier Reference",
+          "_label" : "field|name|OPT-301-Lot-AddInfo",
+          "_idSchemes" : [ "ORG", "TPO" ]
+        } ]
+      }, {
+        "id" : "GR-Lot-DocProvider",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Documents Providing Organisation",
+        "_label" : "group|name|GR-Lot-DocProvider",
+        "content" : [ {
+          "id" : "OPT-301-Lot-DocProvider",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Document Provider Technical Identifier Reference",
+          "_label" : "field|name|OPT-301-Lot-DocProvider",
+          "_idSchemes" : [ "ORG", "TPO" ]
+        } ]
       } ]
     }, {
-      "id" : "GR-Lot-TenderReceipt",
+      "id" : "GR-Lot-Review",
       "contentType" : "group",
-      "displayType" : "GROUP",
-      "description" : "Tender Recipient Organisation",
-      "_label" : "group|name|GR-Lot-TenderReceipt",
+      "displayType" : "SECTION",
+      "description" : "Review",
+      "_label" : "group|name|GR-Lot-Review",
       "content" : [ {
-        "id" : "OPT-301-Lot-TenderReceipt",
-        "contentType" : "field",
-        "displayType" : "COMBOBOX",
-        "description" : "Tender Recipient Technical Identifier Reference",
-        "_label" : "field|name|OPT-301-Lot-TenderReceipt",
-        "_idSchemes" : [ "ORG", "TPO" ]
-      } ]
-    }, {
-      "id" : "GR-Lot-TenderEval",
-      "contentType" : "group",
-      "displayType" : "GROUP",
-      "description" : "Tender Evaluation Organisation",
-      "_label" : "group|name|GR-Lot-TenderEval",
-      "content" : [ {
-        "id" : "OPT-301-Lot-TenderEval",
-        "contentType" : "field",
-        "displayType" : "COMBOBOX",
-        "description" : "Tender Evaluator Technical Identifier Reference",
-        "_label" : "field|name|OPT-301-Lot-TenderEval",
-        "_idSchemes" : [ "ORG", "TPO" ]
+        "id" : "GR-Lot-Deadline",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Review Deadlines",
+        "_label" : "group|name|GR-Lot-Deadline",
+        "content" : [ {
+          "id" : "BT-99-Lot",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Review Deadline Description",
+          "_label" : "field|name|BT-99-Lot"
+        } ]
+      }, {
+        "id" : "GR-Lot-ReviewOrg",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Review Organisation",
+        "_label" : "group|name|GR-Lot-ReviewOrg",
+        "content" : [ {
+          "id" : "OPT-301-Lot-ReviewOrg",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Review Organization Technical Identifier Reference",
+          "_label" : "field|name|OPT-301-Lot-ReviewOrg",
+          "_idSchemes" : [ "ORG", "TPO" ]
+        } ]
+      }, {
+        "id" : "GR-Lot-ReviewInfo",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Review Information Providing Organisation",
+        "_label" : "group|name|GR-Lot-ReviewInfo",
+        "content" : [ {
+          "id" : "OPT-301-Lot-ReviewInfo",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Review Info Provider Technical Identifier Reference",
+          "_label" : "field|name|OPT-301-Lot-ReviewInfo",
+          "_idSchemes" : [ "ORG", "TPO" ]
+        } ]
+      }, {
+        "id" : "GR-Lot-Mediator",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Mediation Organisation",
+        "_label" : "group|name|GR-Lot-Mediator",
+        "content" : [ {
+          "id" : "OPT-301-Lot-Mediator",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Mediator Technical Identifier Reference",
+          "_label" : "field|name|OPT-301-Lot-Mediator",
+          "_idSchemes" : [ "ORG", "TPO" ]
+        } ]
       } ]
     } ]
   }, {
-    "id" : "GR-Lot-SubmissionInfo",
+    "id" : "GR-LotsGroup",
+    "contentType" : "group",
+    "nodeId" : "ND-LotsGroup",
+    "displayType" : "SECTION",
+    "description" : "LotsGroup related information covering Tendering Terms, Tendering Process and Purpose",
+    "_label" : "group|name|ND-LotsGroup",
+    "_idScheme" : "GLO",
+    "_identifierFieldId" : "BT-137-LotsGroup",
+    "_repeatable" : true,
+    "content" : [ {
+      "id" : "GR-LotsGroup-Purpose",
+      "contentType" : "group",
+      "displayType" : "SECTION",
+      "description" : "Purpose",
+      "_label" : "group|name|GR-LotsGroup-Purpose",
+      "content" : [ {
+        "id" : "BT-137-LotsGroup",
+        "contentType" : "field",
+        "displayType" : "TEXTBOX",
+        "description" : "Purpose Lot Identifier",
+        "_label" : "field|name|BT-137-LotsGroup",
+        "_idScheme" : "GLO",
+        "hidden" : true
+      }, {
+        "id" : "GR-LotsGroup-LotDistribution",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Lot Distribution ",
+        "_label" : "group|name|GR-LotsGroup-LotDistribution",
+        "content" : [ {
+          "id" : "BT-330-Procedure",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Group Identifier",
+          "_label" : "field|name|BT-330-Procedure",
+          "valueSource" : "BT-137-LotsGroup",
+          "hidden" : true
+        }, {
+          "id" : "BT-1375-Procedure",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Group Lot Identifier",
+          "_label" : "field|name|BT-1375-Procedure",
+          "_idSchemes" : [ "LOT" ],
+          "_repeatable" : true
+        } ]
+      }, {
+        "id" : "GR-LotsGroup-Description",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Description",
+        "_label" : "group|name|GR-LotsGroup-Description",
+        "content" : [ {
+          "id" : "BT-22-LotsGroup",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Internal Identifier",
+          "_label" : "field|name|BT-22-LotsGroup"
+        }, {
+          "id" : "BT-21-LotsGroup",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Title",
+          "_label" : "field|name|BT-21-LotsGroup"
+        }, {
+          "id" : "BT-24-LotsGroup",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Description",
+          "_label" : "field|name|BT-24-LotsGroup"
+        } ]
+      }, {
+        "id" : "GR-LotsGroup-Scope",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Scope",
+        "_label" : "group|name|GR-LotsGroup-Scope",
+        "content" : [ {
+          "id" : "BT-726-LotsGroup",
+          "contentType" : "field",
+          "displayType" : "RADIO",
+          "description" : "Suitable For SMEs",
+          "_label" : "field|name|BT-726-LotsGroup"
+        }, {
+          "id" : "BT-27-LotsGroup",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Estimated Value",
+          "_label" : "field|name|BT-27-LotsGroup"
+        } ]
+      }, {
+        "id" : "GR-LotsGroup-AdditionalInformation",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Additional Information",
+        "_label" : "group|name|GR-LotsGroup-AdditionalInformation",
+        "content" : [ {
+          "id" : "BT-300-LotsGroup",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Additional Information",
+          "_label" : "field|name|BT-300-LotsGroup"
+        } ]
+      } ]
+    }, {
+      "id" : "GR-LotsGroup-TenderingTerms",
+      "contentType" : "group",
+      "displayType" : "SECTION",
+      "description" : "Tendering Terms",
+      "_label" : "group|name|GR-LotsGroup-TenderingTerms",
+      "content" : [ {
+        "id" : "GR-LotsGroup-AwardCriteria",
+        "contentType" : "group",
+        "nodeId" : "ND-LotsGroupAwardCriteria",
+        "displayType" : "GROUP",
+        "description" : "Award Criteria related information (Description, Justification, Individual Criterion …) for a Group of Lots",
+        "_label" : "group|name|ND-LotsGroupAwardCriteria",
+        "_repeatable" : true,
+        "content" : [ {
+          "id" : "GR-LotsGroup-AwardCriteria-Criterion",
+          "contentType" : "group",
+          "nodeId" : "ND-LotsGroupAwardCriterion",
+          "displayType" : "GROUP",
+          "description" : "Award Criterion related information (Description, Name, Parameter, Code …) for a Group of Lots",
+          "_label" : "group|name|ND-LotsGroupAwardCriterion",
+          "_repeatable" : true,
+          "content" : [ {
+            "id" : "BT-539-LotsGroup",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "Award Criterion Type",
+            "_label" : "field|name|BT-539-LotsGroup"
+          }, {
+            "id" : "BT-540-LotsGroup",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Award Criterion Description",
+            "_label" : "field|name|BT-540-LotsGroup"
+          }, {
+            "id" : "GR-LotsGroup-AwardCriteria-Criterion-Parameters",
+            "contentType" : "group",
+            "nodeId" : "ND-LotsGroupAwardCriterionParameters",
+            "displayType" : "GROUP",
+            "description" : "Non UBL Native Subordinate Award Criteria elements for a Group of Lots",
+            "_label" : "group|name|ND-LotsGroupAwardCriterionParameters",
+            "content" : [ {
+              "id" : "GR-LotsGroup-AwardCriteria-Criterion-Parameter",
+              "contentType" : "group",
+              "nodeId" : "ND-LotsGroupAwardCriterionParameter",
+              "displayType" : "GROUP",
+              "description" : "Group of Lots Award Criterion Parameter (Value and associated Code)",
+              "_label" : "group|name|ND-LotsGroupAwardCriterionParameter",
+              "content" : [ {
+                "id" : "BT-541-LotsGroup",
+                "contentType" : "field",
+                "displayType" : "TEXTBOX",
+                "description" : "Award Criterion Number",
+                "_label" : "field|name|BT-541-LotsGroup"
+              }, {
+                "id" : "BT-5421-LotsGroup",
+                "contentType" : "field",
+                "displayType" : "COMBOBOX",
+                "description" : "Award Criterion Number Weight",
+                "_label" : "field|name|BT-5421-LotsGroup"
+              }, {
+                "id" : "BT-5422-LotsGroup",
+                "contentType" : "field",
+                "displayType" : "COMBOBOX",
+                "description" : "Award Criterion Number Fixed",
+                "_label" : "field|name|BT-5422-LotsGroup"
+              }, {
+                "id" : "BT-5423-LotsGroup",
+                "contentType" : "field",
+                "displayType" : "COMBOBOX",
+                "description" : "Award Criterion Number Threshold",
+                "_label" : "field|name|BT-5423-LotsGroup"
+              } ]
+            } ]
+          }, {
+            "id" : "BT-734-LotsGroup",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Award Criterion Name",
+            "_label" : "field|name|BT-734-LotsGroup"
+          } ]
+        }, {
+          "id" : "BT-543-LotsGroup",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Award Criteria Complicated",
+          "_label" : "field|name|BT-543-LotsGroup"
+        }, {
+          "id" : "BT-733-LotsGroup",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Award Criteria Order Justification",
+          "_label" : "field|name|BT-733-LotsGroup"
+        } ]
+      } ]
+    } ]
+  }, {
+    "id" : "GR-Change",
     "contentType" : "group",
     "displayType" : "SECTION",
-    "description" : "Submission Info",
-    "_label" : "group|name|GR-Lot-SubmissionInfo",
+    "description" : "Change",
+    "_label" : "group|name|GR-Change",
     "content" : [ {
-      "id" : "GR-Lot-Procedure",
-      "contentType" : "group",
-      "displayType" : "GROUP",
-      "description" : "Procedure",
-      "_label" : "group|name|GR-Lot-Procedure",
-      "content" : [ {
-        "id" : "BT-634-Lot",
-        "contentType" : "field",
-        "displayType" : "RADIO",
-        "description" : "Procurement Relaunch",
-        "_label" : "field|name|BT-634-Lot"
-      } ]
+      "id" : "BT-140-notice",
+      "contentType" : "field",
+      "displayType" : "COMBOBOX",
+      "description" : "Change Reason Code",
+      "_label" : "field|name|BT-140-notice",
+      "readOnly" : true
     }, {
-      "id" : "GR-Lot-Deadlines1",
-      "contentType" : "group",
-      "displayType" : "GROUP",
-      "description" : "Deadlines I",
-      "_label" : "group|name|GR-Lot-Deadlines1",
-      "content" : [ {
-        "id" : "BT-130-Lot",
-        "contentType" : "field",
-        "displayType" : "TEXTBOX",
-        "description" : "Dispatch Invitation Tender",
-        "_label" : "field|name|BT-130-Lot"
-      }, {
-        "id" : "BT-631-Lot",
-        "contentType" : "field",
-        "displayType" : "TEXTBOX",
-        "description" : "Dispatch Invitation Interest",
-        "_label" : "field|name|BT-631-Lot"
-      }, {
-        "id" : "BT-13(d)-Lot",
-        "contentType" : "field",
-        "displayType" : "TEXTBOX",
-        "description" : "Additional Information Deadline",
-        "_label" : "field|name|BT-13(d)-Lot"
-      }, {
-        "id" : "BT-13(t)-Lot",
-        "contentType" : "field",
-        "displayType" : "TEXTBOX",
-        "description" : "Additional Information Deadline",
-        "_label" : "field|name|BT-13(t)-Lot"
-      } ]
+      "id" : "BT-762-notice",
+      "contentType" : "field",
+      "displayType" : "TEXTAREA",
+      "description" : "Change Reason Description",
+      "_label" : "field|name|BT-762-notice"
     }, {
-      "id" : "GR-Lot-Deadlines2",
-      "contentType" : "group",
-      "displayType" : "GROUP",
-      "description" : "Deadlines II",
-      "_label" : "group|name|GR-Lot-Deadlines2",
-      "content" : [ {
-        "id" : "BT-630(d)-Lot",
-        "contentType" : "field",
-        "displayType" : "TEXTBOX",
-        "description" : "Deadline Receipt Expressions",
-        "_label" : "field|name|BT-630(d)-Lot"
-      }, {
-        "id" : "BT-630(t)-Lot",
-        "contentType" : "field",
-        "displayType" : "TEXTBOX",
-        "description" : "Deadline Receipt Expressions",
-        "_label" : "field|name|BT-630(t)-Lot"
-      } ]
+      "id" : "BT-758-notice",
+      "contentType" : "field",
+      "displayType" : "TEXTBOX",
+      "description" : "Change Notice Version Identifier",
+      "_label" : "field|name|BT-758-notice",
+      "readOnly" : true
     }, {
-      "id" : "GR-Lot-Submission Language",
+      "id" : "GR-ChangeSections",
       "contentType" : "group",
+      "nodeId" : "ND-Change",
       "displayType" : "GROUP",
-      "description" : "Submission Language",
-      "_label" : "group|name|GR-Lot-Submission Language",
-      "content" : [ {
-        "id" : "BT-97-Lot",
-        "contentType" : "field",
-        "displayType" : "COMBOBOX",
-        "description" : "Submission Language",
-        "_label" : "field|name|BT-97-Lot",
-        "_repeatable" : true
-      } ]
-    }, {
-      "id" : "GR-Lot-FinancialGuarantee",
-      "contentType" : "group",
-      "displayType" : "GROUP",
-      "description" : "Financial Guarantee",
-      "_label" : "group|name|GR-Lot-FinancialGuarantee",
-      "content" : [ {
-        "id" : "BT-751-Lot",
-        "contentType" : "field",
-        "displayType" : "COMBOBOX",
-        "description" : "Guarantee Required",
-        "_label" : "field|name|BT-751-Lot"
-      }, {
-        "id" : "BT-75-Lot",
-        "contentType" : "field",
-        "displayType" : "TEXTAREA",
-        "description" : "Guarantee Required Description",
-        "_label" : "field|name|BT-75-Lot"
-      } ]
-    }, {
-      "id" : "GR-Lot-SubmissionMethod",
-      "contentType" : "group",
-      "displayType" : "GROUP",
-      "description" : "Submission Method",
-      "_label" : "group|name|GR-Lot-SubmissionMethod",
-      "content" : [ {
-        "id" : "BT-17-Lot",
-        "contentType" : "field",
-        "displayType" : "COMBOBOX",
-        "description" : "SubmissionElectronic",
-        "_label" : "field|name|BT-17-Lot"
-      }, {
-        "id" : "BT-18-Lot",
-        "contentType" : "field",
-        "displayType" : "TEXTBOX",
-        "description" : "Submission URL",
-        "_label" : "field|name|BT-18-Lot"
-      }, {
-        "id" : "BT-19-Lot",
-        "contentType" : "field",
-        "displayType" : "COMBOBOX",
-        "description" : "Submission Nonelectronic Justification",
-        "_label" : "field|name|BT-19-Lot"
-      }, {
-        "id" : "BT-745-Lot",
-        "contentType" : "field",
-        "displayType" : "TEXTAREA",
-        "description" : "Submission Nonelectronic Description",
-        "_label" : "field|name|BT-745-Lot"
-      } ]
-    }, {
-      "id" : "GR-Lot-ProcurementDocuments",
-      "contentType" : "group",
-      "nodeId" : "ND-LotProcurementDocument",
-      "displayType" : "GROUP",
-      "description" : "Procurement Document information for a Lot, independent from the restricted aspect",
-      "_label" : "group|name|ND-LotProcurementDocument",
+      "description" : "Information associated to a single Change (Section, Description & Procurement Documents)",
+      "_label" : "group|name|ND-Change",
       "_repeatable" : true,
       "content" : [ {
-        "id" : "BT-14-Lot",
-        "contentType" : "field",
-        "displayType" : "COMBOBOX",
-        "description" : "Documents Restricted",
-        "_label" : "field|name|BT-14-Lot"
-      }, {
-        "id" : "OPT-050-Lot",
-        "contentType" : "field",
-        "displayType" : "COMBOBOX",
-        "description" : "Document Status",
-        "_label" : "field|name|OPT-050-Lot"
-      }, {
-        "id" : "BT-707-Lot",
-        "contentType" : "field",
-        "displayType" : "COMBOBOX",
-        "description" : "Documents Restricted Justification",
-        "_label" : "field|name|BT-707-Lot"
-      }, {
-        "id" : "BT-708-Lot",
-        "contentType" : "field",
-        "displayType" : "COMBOBOX",
-        "description" : "Documents Official Language",
-        "_label" : "field|name|BT-708-Lot"
-      }, {
-        "id" : "BT-737-Lot",
-        "contentType" : "field",
-        "displayType" : "COMBOBOX",
-        "description" : "Documents Unofficial Language",
-        "_label" : "field|name|BT-737-Lot"
-      }, {
-        "id" : "BT-15-Lot",
+        "id" : "BT-13716-notice",
         "contentType" : "field",
         "displayType" : "TEXTBOX",
-        "description" : "Documents URL",
-        "_label" : "field|name|BT-15-Lot"
+        "description" : "Change Previous Section Identifier",
+        "_label" : "field|name|BT-13716-notice",
+        "_repeatable" : true
       }, {
-        "id" : "BT-615-Lot",
-        "contentType" : "field",
-        "displayType" : "TEXTBOX",
-        "description" : "Documents Restricted URL",
-        "_label" : "field|name|BT-615-Lot"
-      }, {
-        "id" : "OPT-140-Lot",
-        "contentType" : "field",
-        "displayType" : "TEXTBOX",
-        "description" : "Procurement Documents ID",
-        "_label" : "field|name|OPT-140-Lot"
-      } ]
-    }, {
-      "id" : "GR-Lot-SubmissionTool",
-      "contentType" : "group",
-      "displayType" : "GROUP",
-      "description" : "Submission Tool",
-      "_label" : "group|name|GR-Lot-SubmissionTool",
-      "content" : [ {
-        "id" : "BT-632-Lot",
+        "id" : "BT-141(a)-notice",
         "contentType" : "field",
         "displayType" : "TEXTAREA",
-        "description" : "Tool Name",
-        "_label" : "field|name|BT-632-Lot"
+        "description" : "Change Description",
+        "_label" : "field|name|BT-141(a)-notice"
       }, {
-        "id" : "BT-124-Lot",
+        "id" : "BT-718-notice",
+        "contentType" : "field",
+        "displayType" : "RADIO",
+        "description" : "Change Procurement Documents",
+        "_label" : "field|name|BT-718-notice"
+      }, {
+        "id" : "BT-719-notice",
         "contentType" : "field",
         "displayType" : "TEXTBOX",
-        "description" : "Tool Atypical URL",
-        "_label" : "field|name|BT-124-Lot"
-      } ]
-    }, {
-      "id" : "GR-Lot-AddInfo",
-      "contentType" : "group",
-      "displayType" : "GROUP",
-      "description" : "Additional Information Providing Organisation",
-      "_label" : "group|name|GR-Lot-AddInfo",
-      "content" : [ {
-        "id" : "OPT-301-Lot-AddInfo",
-        "contentType" : "field",
-        "displayType" : "COMBOBOX",
-        "description" : "Additional Info Provider Technical Identifier Reference",
-        "_label" : "field|name|OPT-301-Lot-AddInfo",
-        "_idSchemes" : [ "ORG", "TPO" ]
-      } ]
-    }, {
-      "id" : "GR-Lot-DocProvider",
-      "contentType" : "group",
-      "displayType" : "GROUP",
-      "description" : "Documents Providing Organisation",
-      "_label" : "group|name|GR-Lot-DocProvider",
-      "content" : [ {
-        "id" : "OPT-301-Lot-DocProvider",
-        "contentType" : "field",
-        "displayType" : "COMBOBOX",
-        "description" : "Document Provider Technical Identifier Reference",
-        "_label" : "field|name|OPT-301-Lot-DocProvider",
-        "_idSchemes" : [ "ORG", "TPO" ]
+        "description" : "Change Procurement Documents Date",
+        "_label" : "field|name|BT-719-notice"
       } ]
     } ]
   }, {
-    "id" : "GR-Lot-Review",
+    "id" : "GR-Organisations-Section",
     "contentType" : "group",
     "displayType" : "SECTION",
-    "description" : "Review",
-    "_label" : "group|name|GR-Lot-Review",
+    "description" : "Organisations",
+    "_label" : "group|name|GR-Organisations-Section",
     "content" : [ {
-      "id" : "GR-Lot-Deadline",
+      "id" : "GR-Organisations-Subsection",
       "contentType" : "group",
-      "displayType" : "GROUP",
-      "description" : "Review Deadlines",
-      "_label" : "group|name|GR-Lot-Deadline",
+      "displayType" : "SECTION",
+      "description" : "Organisations",
+      "_label" : "group|name|GR-Organisations-Subsection",
       "content" : [ {
-        "id" : "BT-99-Lot",
-        "contentType" : "field",
-        "displayType" : "TEXTAREA",
-        "description" : "Review Deadline Description",
-        "_label" : "field|name|BT-99-Lot"
-      } ]
-    }, {
-      "id" : "GR-Lot-ReviewOrg",
-      "contentType" : "group",
-      "displayType" : "GROUP",
-      "description" : "Review Organisation",
-      "_label" : "group|name|GR-Lot-ReviewOrg",
-      "content" : [ {
-        "id" : "OPT-301-Lot-ReviewOrg",
-        "contentType" : "field",
-        "displayType" : "COMBOBOX",
-        "description" : "Review Organization Technical Identifier Reference",
-        "_label" : "field|name|OPT-301-Lot-ReviewOrg",
-        "_idSchemes" : [ "ORG", "TPO" ]
-      } ]
-    }, {
-      "id" : "GR-Lot-ReviewInfo",
-      "contentType" : "group",
-      "displayType" : "GROUP",
-      "description" : "Review Information Providing Organisation",
-      "_label" : "group|name|GR-Lot-ReviewInfo",
-      "content" : [ {
-        "id" : "OPT-301-Lot-ReviewInfo",
-        "contentType" : "field",
-        "displayType" : "COMBOBOX",
-        "description" : "Review Info Provider Technical Identifier Reference",
-        "_label" : "field|name|OPT-301-Lot-ReviewInfo",
-        "_idSchemes" : [ "ORG", "TPO" ]
-      } ]
-    }, {
-      "id" : "GR-Lot-Mediator",
-      "contentType" : "group",
-      "displayType" : "GROUP",
-      "description" : "Mediation Organisation",
-      "_label" : "group|name|GR-Lot-Mediator",
-      "content" : [ {
-        "id" : "OPT-301-Lot-Mediator",
-        "contentType" : "field",
-        "displayType" : "COMBOBOX",
-        "description" : "Mediator Technical Identifier Reference",
-        "_label" : "field|name|OPT-301-Lot-Mediator",
-        "_idSchemes" : [ "ORG", "TPO" ]
+        "id" : "GR-Organisations",
+        "contentType" : "group",
+        "nodeId" : "ND-Organization",
+        "displayType" : "GROUP",
+        "description" : "A Party involved in the Competition from either side (Buyer or Tenderer) with a Legal Entity (Company) and possibly additional Contact Points (touchpoints)",
+        "_label" : "group|name|ND-Organization",
+        "_idScheme" : "ORG",
+        "_identifierFieldId" : "OPT-200-Organization-Company",
+        "_repeatable" : true,
+        "content" : [ {
+          "id" : "OPT-200-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Organisation Technical Identifier",
+          "_label" : "field|name|OPT-200-Organization-Company",
+          "_idScheme" : "ORG",
+          "hidden" : true
+        }, {
+          "id" : "BT-633-Organization",
+          "contentType" : "field",
+          "displayType" : "RADIO",
+          "description" : "Organisation Natural Person",
+          "_label" : "field|name|BT-633-Organization"
+        }, {
+          "id" : "GR-Company",
+          "contentType" : "group",
+          "displayType" : "GROUP",
+          "description" : "Organisation",
+          "_label" : "group|name|GR-Company",
+          "content" : [ {
+            "id" : "BT-500-Organization-Company",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Organisation Name",
+            "_label" : "field|name|BT-500-Organization-Company"
+          }, {
+            "id" : "BT-501-Organization-Company",
+            "contentType" : "field",
+            "displayType" : "TEXTBOX",
+            "description" : "Organisation Identifier",
+            "_label" : "field|name|BT-501-Organization-Company",
+            "_repeatable" : true
+          }, {
+            "id" : "BT-16-Organization-Company",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Organisation Part Name",
+            "_label" : "field|name|BT-16-Organization-Company"
+          }, {
+            "id" : "BT-505-Organization-Company",
+            "contentType" : "field",
+            "displayType" : "TEXTBOX",
+            "description" : "Organisation Internet Address",
+            "_label" : "field|name|BT-505-Organization-Company"
+          }, {
+            "id" : "BT-509-Organization-Company",
+            "contentType" : "field",
+            "displayType" : "TEXTBOX",
+            "description" : "Organisation eDelivery Gateway",
+            "_label" : "field|name|BT-509-Organization-Company"
+          } ]
+        }, {
+          "id" : "GR-Company-Address",
+          "contentType" : "group",
+          "displayType" : "GROUP",
+          "description" : "Organisation Address",
+          "_label" : "group|name|GR-Company-Address",
+          "content" : [ {
+            "id" : "BT-510(a)-Organization-Company",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Street",
+            "_label" : "field|name|BT-510(a)-Organization-Company"
+          }, {
+            "id" : "BT-510(b)-Organization-Company",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Streetline 1",
+            "_label" : "field|name|BT-510(b)-Organization-Company"
+          }, {
+            "id" : "BT-510(c)-Organization-Company",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Streetline 2",
+            "_label" : "field|name|BT-510(c)-Organization-Company"
+          }, {
+            "id" : "BT-513-Organization-Company",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Organisation City",
+            "_label" : "field|name|BT-513-Organization-Company"
+          }, {
+            "id" : "BT-512-Organization-Company",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Organisation Post Code",
+            "_label" : "field|name|BT-512-Organization-Company"
+          }, {
+            "id" : "BT-507-Organization-Company",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "Organisation Country Subdivision",
+            "_label" : "field|name|BT-507-Organization-Company"
+          }, {
+            "id" : "BT-514-Organization-Company",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "Organisation Country Code",
+            "_label" : "field|name|BT-514-Organization-Company"
+          } ]
+        }, {
+          "id" : "GR-Company-Contact",
+          "contentType" : "group",
+          "displayType" : "GROUP",
+          "description" : "Organisation Contact",
+          "_label" : "group|name|GR-Company-Contact",
+          "content" : [ {
+            "id" : "BT-502-Organization-Company",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Organisation Contact Point",
+            "_label" : "field|name|BT-502-Organization-Company"
+          }, {
+            "id" : "BT-506-Organization-Company",
+            "contentType" : "field",
+            "displayType" : "TEXTBOX",
+            "description" : "Organisation Contact Email Address",
+            "_label" : "field|name|BT-506-Organization-Company"
+          }, {
+            "id" : "BT-503-Organization-Company",
+            "contentType" : "field",
+            "displayType" : "TEXTBOX",
+            "description" : "Organisation Contact Telephone Number",
+            "_label" : "field|name|BT-503-Organization-Company"
+          }, {
+            "id" : "BT-739-Organization-Company",
+            "contentType" : "field",
+            "displayType" : "TEXTBOX",
+            "description" : "Organisation Contact Fax",
+            "_label" : "field|name|BT-739-Organization-Company"
+          } ]
+        }, {
+          "id" : "GR-Company-BuyerExclusive",
+          "contentType" : "group",
+          "displayType" : "GROUP",
+          "description" : "Buyer Exclusive",
+          "_label" : "group|name|GR-Company-BuyerExclusive",
+          "content" : [ {
+            "id" : "OPP-050-Organization",
+            "contentType" : "field",
+            "displayType" : "RADIO",
+            "description" : "Buyers Group Lead Indicator",
+            "_label" : "field|name|OPP-050-Organization"
+          } ]
+        }, {
+          "id" : "GR-Touch-Point",
+          "contentType" : "group",
+          "nodeId" : "ND-Touchpoint",
+          "displayType" : "GROUP",
+          "description" : "Contact details associated to a given role",
+          "_label" : "group|name|ND-Touchpoint",
+          "_idScheme" : "TPO",
+          "_identifierFieldId" : "OPT-201-Organization-TouchPoint",
+          "_repeatable" : true,
+          "content" : [ {
+            "id" : "OPT-201-Organization-TouchPoint",
+            "contentType" : "field",
+            "displayType" : "TEXTBOX",
+            "description" : "TouchPoint Technical Identifier",
+            "_label" : "field|name|OPT-201-Organization-TouchPoint",
+            "_idScheme" : "TPO",
+            "hidden" : true
+          }, {
+            "id" : "BT-500-Organization-TouchPoint",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Name",
+            "_label" : "field|name|BT-500-Organization-TouchPoint"
+          }, {
+            "id" : "BT-16-Organization-TouchPoint",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Part Name",
+            "_label" : "field|name|BT-16-Organization-TouchPoint"
+          }, {
+            "id" : "BT-505-Organization-TouchPoint",
+            "contentType" : "field",
+            "displayType" : "TEXTBOX",
+            "description" : "Internet Address",
+            "_label" : "field|name|BT-505-Organization-TouchPoint"
+          }, {
+            "id" : "BT-509-Organization-TouchPoint",
+            "contentType" : "field",
+            "displayType" : "TEXTBOX",
+            "description" : "eDelivery Gateway",
+            "_label" : "field|name|BT-509-Organization-TouchPoint"
+          }, {
+            "id" : "GR-TouchPoint-Address",
+            "contentType" : "group",
+            "displayType" : "GROUP",
+            "description" : "TouchPoint Address",
+            "_label" : "group|name|GR-TouchPoint-Address",
+            "content" : [ {
+              "id" : "BT-510(a)-Organization-TouchPoint",
+              "contentType" : "field",
+              "displayType" : "TEXTAREA",
+              "description" : "Street",
+              "_label" : "field|name|BT-510(a)-Organization-TouchPoint"
+            }, {
+              "id" : "BT-510(b)-Organization-TouchPoint",
+              "contentType" : "field",
+              "displayType" : "TEXTAREA",
+              "description" : "Streetline 1",
+              "_label" : "field|name|BT-510(b)-Organization-TouchPoint"
+            }, {
+              "id" : "BT-510(c)-Organization-TouchPoint",
+              "contentType" : "field",
+              "displayType" : "TEXTAREA",
+              "description" : "Streetline 2",
+              "_label" : "field|name|BT-510(c)-Organization-TouchPoint"
+            }, {
+              "id" : "BT-513-Organization-TouchPoint",
+              "contentType" : "field",
+              "displayType" : "TEXTAREA",
+              "description" : "City",
+              "_label" : "field|name|BT-513-Organization-TouchPoint"
+            }, {
+              "id" : "BT-512-Organization-TouchPoint",
+              "contentType" : "field",
+              "displayType" : "TEXTAREA",
+              "description" : "Post Code",
+              "_label" : "field|name|BT-512-Organization-TouchPoint"
+            }, {
+              "id" : "BT-507-Organization-TouchPoint",
+              "contentType" : "field",
+              "displayType" : "COMBOBOX",
+              "description" : "Country Subdivision",
+              "_label" : "field|name|BT-507-Organization-TouchPoint"
+            }, {
+              "id" : "BT-514-Organization-TouchPoint",
+              "contentType" : "field",
+              "displayType" : "COMBOBOX",
+              "description" : "Country Code",
+              "_label" : "field|name|BT-514-Organization-TouchPoint"
+            } ]
+          }, {
+            "id" : "GR-TouchPoint-Contact",
+            "contentType" : "group",
+            "displayType" : "GROUP",
+            "description" : "TouchPoint Contact",
+            "_label" : "group|name|GR-TouchPoint-Contact",
+            "content" : [ {
+              "id" : "BT-502-Organization-TouchPoint",
+              "contentType" : "field",
+              "displayType" : "TEXTAREA",
+              "description" : "Contact Point",
+              "_label" : "field|name|BT-502-Organization-TouchPoint"
+            }, {
+              "id" : "BT-506-Organization-TouchPoint",
+              "contentType" : "field",
+              "displayType" : "TEXTBOX",
+              "description" : "Contact Email Address",
+              "_label" : "field|name|BT-506-Organization-TouchPoint"
+            }, {
+              "id" : "BT-503-Organization-TouchPoint",
+              "contentType" : "field",
+              "displayType" : "TEXTBOX",
+              "description" : "Contact Telephone Number",
+              "_label" : "field|name|BT-503-Organization-TouchPoint"
+            }, {
+              "id" : "BT-739-Organization-TouchPoint",
+              "contentType" : "field",
+              "displayType" : "TEXTBOX",
+              "description" : "Contact Fax",
+              "_label" : "field|name|BT-739-Organization-TouchPoint"
+            } ]
+          } ]
+        } ]
       } ]
     } ]
   } ]

--- a/notice-types/15.json
+++ b/notice-types/15.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "15",
   "metadata" : [ {
@@ -1125,17 +1125,25 @@
           "description" : "Tenderer Legal Form Description",
           "_label" : "field|name|BT-76-Lot"
         }, {
-          "id" : "BT-771-Lot",
-          "contentType" : "field",
-          "displayType" : "COMBOBOX",
-          "description" : "Late Tenderer Information",
-          "_label" : "field|name|BT-771-Lot"
-        }, {
-          "id" : "BT-772-Lot",
-          "contentType" : "field",
-          "displayType" : "TEXTAREA",
-          "description" : "Late Tenderer Information Description",
-          "_label" : "field|name|BT-772-Lot"
+          "id" : "GR-LateTendererInformation",
+          "contentType" : "group",
+          "nodeId" : "ND-LateTendererInformation",
+          "displayType" : "GROUP",
+          "description" : "Information about late provision of information by the tenderer (possibility and description of the information)",
+          "_label" : "group|name|ND-LateTendererInformation",
+          "content" : [ {
+            "id" : "BT-771-Lot",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "Late Tenderer Information",
+            "_label" : "field|name|BT-771-Lot"
+          }, {
+            "id" : "BT-772-Lot",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Late Tenderer Information Description",
+            "_label" : "field|name|BT-772-Lot"
+          } ]
         }, {
           "id" : "GR-ReservedParticipation",
           "contentType" : "group",

--- a/notice-types/16.json
+++ b/notice-types/16.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "16",
   "metadata" : [ {
@@ -1348,17 +1348,25 @@
           "description" : "Tenderer Legal Form Description",
           "_label" : "field|name|BT-76-Lot"
         }, {
-          "id" : "BT-771-Lot",
-          "contentType" : "field",
-          "displayType" : "COMBOBOX",
-          "description" : "Late Tenderer Information",
-          "_label" : "field|name|BT-771-Lot"
-        }, {
-          "id" : "BT-772-Lot",
-          "contentType" : "field",
-          "displayType" : "TEXTAREA",
-          "description" : "Late Tenderer Information Description",
-          "_label" : "field|name|BT-772-Lot"
+          "id" : "GR-LateTendererInformation",
+          "contentType" : "group",
+          "nodeId" : "ND-LateTendererInformation",
+          "displayType" : "GROUP",
+          "description" : "Information about late provision of information by the tenderer (possibility and description of the information)",
+          "_label" : "group|name|ND-LateTendererInformation",
+          "content" : [ {
+            "id" : "BT-771-Lot",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "Late Tenderer Information",
+            "_label" : "field|name|BT-771-Lot"
+          }, {
+            "id" : "BT-772-Lot",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Late Tenderer Information Description",
+            "_label" : "field|name|BT-772-Lot"
+          } ]
         }, {
           "id" : "GR-ReservedParticipation",
           "contentType" : "group",

--- a/notice-types/17.json
+++ b/notice-types/17.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "17",
   "metadata" : [ {
@@ -1341,17 +1341,25 @@
           "description" : "Tenderer Legal Form Description",
           "_label" : "field|name|BT-76-Lot"
         }, {
-          "id" : "BT-771-Lot",
-          "contentType" : "field",
-          "displayType" : "COMBOBOX",
-          "description" : "Late Tenderer Information",
-          "_label" : "field|name|BT-771-Lot"
-        }, {
-          "id" : "BT-772-Lot",
-          "contentType" : "field",
-          "displayType" : "TEXTAREA",
-          "description" : "Late Tenderer Information Description",
-          "_label" : "field|name|BT-772-Lot"
+          "id" : "GR-LateTendererInformation",
+          "contentType" : "group",
+          "nodeId" : "ND-LateTendererInformation",
+          "displayType" : "GROUP",
+          "description" : "Information about late provision of information by the tenderer (possibility and description of the information)",
+          "_label" : "group|name|ND-LateTendererInformation",
+          "content" : [ {
+            "id" : "BT-771-Lot",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "Late Tenderer Information",
+            "_label" : "field|name|BT-771-Lot"
+          }, {
+            "id" : "BT-772-Lot",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Late Tenderer Information Description",
+            "_label" : "field|name|BT-772-Lot"
+          } ]
         }, {
           "id" : "GR-ReservedParticipation",
           "contentType" : "group",

--- a/notice-types/18.json
+++ b/notice-types/18.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "18",
   "metadata" : [ {
@@ -1328,17 +1328,25 @@
           "description" : "Tenderer Legal Form Description",
           "_label" : "field|name|BT-76-Lot"
         }, {
-          "id" : "BT-771-Lot",
-          "contentType" : "field",
-          "displayType" : "COMBOBOX",
-          "description" : "Late Tenderer Information",
-          "_label" : "field|name|BT-771-Lot"
-        }, {
-          "id" : "BT-772-Lot",
-          "contentType" : "field",
-          "displayType" : "TEXTAREA",
-          "description" : "Late Tenderer Information Description",
-          "_label" : "field|name|BT-772-Lot"
+          "id" : "GR-LateTendererInformation",
+          "contentType" : "group",
+          "nodeId" : "ND-LateTendererInformation",
+          "displayType" : "GROUP",
+          "description" : "Information about late provision of information by the tenderer (possibility and description of the information)",
+          "_label" : "group|name|ND-LateTendererInformation",
+          "content" : [ {
+            "id" : "BT-771-Lot",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "Late Tenderer Information",
+            "_label" : "field|name|BT-771-Lot"
+          }, {
+            "id" : "BT-772-Lot",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Late Tenderer Information Description",
+            "_label" : "field|name|BT-772-Lot"
+          } ]
         }, {
           "id" : "GR-ReservedParticipation",
           "contentType" : "group",

--- a/notice-types/19.json
+++ b/notice-types/19.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "19",
   "metadata" : [ {
@@ -1205,17 +1205,25 @@
           "description" : "Tenderer Legal Form Description",
           "_label" : "field|name|BT-76-Lot"
         }, {
-          "id" : "BT-771-Lot",
-          "contentType" : "field",
-          "displayType" : "COMBOBOX",
-          "description" : "Late Tenderer Information",
-          "_label" : "field|name|BT-771-Lot"
-        }, {
-          "id" : "BT-772-Lot",
-          "contentType" : "field",
-          "displayType" : "TEXTAREA",
-          "description" : "Late Tenderer Information Description",
-          "_label" : "field|name|BT-772-Lot"
+          "id" : "GR-LateTendererInformation",
+          "contentType" : "group",
+          "nodeId" : "ND-LateTendererInformation",
+          "displayType" : "GROUP",
+          "description" : "Information about late provision of information by the tenderer (possibility and description of the information)",
+          "_label" : "group|name|ND-LateTendererInformation",
+          "content" : [ {
+            "id" : "BT-771-Lot",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "Late Tenderer Information",
+            "_label" : "field|name|BT-771-Lot"
+          }, {
+            "id" : "BT-772-Lot",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Late Tenderer Information Description",
+            "_label" : "field|name|BT-772-Lot"
+          } ]
         }, {
           "id" : "GR-ReservedParticipation",
           "contentType" : "group",

--- a/notice-types/20.json
+++ b/notice-types/20.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "20",
   "metadata" : [ {
@@ -1323,17 +1323,25 @@
           "description" : "Tenderer Legal Form Description",
           "_label" : "field|name|BT-76-Lot"
         }, {
-          "id" : "BT-771-Lot",
-          "contentType" : "field",
-          "displayType" : "COMBOBOX",
-          "description" : "Late Tenderer Information",
-          "_label" : "field|name|BT-771-Lot"
-        }, {
-          "id" : "BT-772-Lot",
-          "contentType" : "field",
-          "displayType" : "TEXTAREA",
-          "description" : "Late Tenderer Information Description",
-          "_label" : "field|name|BT-772-Lot"
+          "id" : "GR-LateTendererInformation",
+          "contentType" : "group",
+          "nodeId" : "ND-LateTendererInformation",
+          "displayType" : "GROUP",
+          "description" : "Information about late provision of information by the tenderer (possibility and description of the information)",
+          "_label" : "group|name|ND-LateTendererInformation",
+          "content" : [ {
+            "id" : "BT-771-Lot",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "Late Tenderer Information",
+            "_label" : "field|name|BT-771-Lot"
+          }, {
+            "id" : "BT-772-Lot",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Late Tenderer Information Description",
+            "_label" : "field|name|BT-772-Lot"
+          } ]
         }, {
           "id" : "GR-ReservedParticipation",
           "contentType" : "group",

--- a/notice-types/21.json
+++ b/notice-types/21.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "21",
   "metadata" : [ {
@@ -1316,17 +1316,25 @@
           "description" : "Tenderer Legal Form Description",
           "_label" : "field|name|BT-76-Lot"
         }, {
-          "id" : "BT-771-Lot",
-          "contentType" : "field",
-          "displayType" : "COMBOBOX",
-          "description" : "Late Tenderer Information",
-          "_label" : "field|name|BT-771-Lot"
-        }, {
-          "id" : "BT-772-Lot",
-          "contentType" : "field",
-          "displayType" : "TEXTAREA",
-          "description" : "Late Tenderer Information Description",
-          "_label" : "field|name|BT-772-Lot"
+          "id" : "GR-LateTendererInformation",
+          "contentType" : "group",
+          "nodeId" : "ND-LateTendererInformation",
+          "displayType" : "GROUP",
+          "description" : "Information about late provision of information by the tenderer (possibility and description of the information)",
+          "_label" : "group|name|ND-LateTendererInformation",
+          "content" : [ {
+            "id" : "BT-771-Lot",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "Late Tenderer Information",
+            "_label" : "field|name|BT-771-Lot"
+          }, {
+            "id" : "BT-772-Lot",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Late Tenderer Information Description",
+            "_label" : "field|name|BT-772-Lot"
+          } ]
         }, {
           "id" : "GR-ReservedParticipation",
           "contentType" : "group",

--- a/notice-types/23.json
+++ b/notice-types/23.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "23",
   "metadata" : [ {
@@ -1176,11 +1176,12 @@
           "_repeatable" : true
         } ]
       }, {
-        "id" : "GR-Lot-TendererQualification",
+        "id" : "GR-LateTendererInformation",
         "contentType" : "group",
+        "nodeId" : "ND-LateTendererInformation",
         "displayType" : "GROUP",
-        "description" : "Tenderer Qualification",
-        "_label" : "group|name|GR-Lot-TendererQualification",
+        "description" : "Information about late provision of information by the tenderer (possibility and description of the information)",
+        "_label" : "group|name|ND-LateTendererInformation",
         "content" : [ {
           "id" : "BT-771-Lot",
           "contentType" : "field",

--- a/notice-types/24.json
+++ b/notice-types/24.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "24",
   "metadata" : [ {
@@ -1182,11 +1182,12 @@
           "_repeatable" : true
         } ]
       }, {
-        "id" : "GR-Lot-TendererQualification",
+        "id" : "GR-LateTendererInformation",
         "contentType" : "group",
+        "nodeId" : "ND-LateTendererInformation",
         "displayType" : "GROUP",
-        "description" : "Tenderer Qualification",
-        "_label" : "group|name|GR-Lot-TendererQualification",
+        "description" : "Information about late provision of information by the tenderer (possibility and description of the information)",
+        "_label" : "group|name|ND-LateTendererInformation",
         "content" : [ {
           "id" : "BT-771-Lot",
           "contentType" : "field",

--- a/notice-types/29.json
+++ b/notice-types/29.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "29",
   "metadata" : [ {
@@ -2885,10 +2885,10 @@
         }, {
           "id" : "GR-LotResult-ReviewRequests",
           "contentType" : "group",
-          "nodeId" : "ND-LotResult",
+          "nodeId" : "ND-ReviewRequestsStatistics",
           "displayType" : "GROUP",
-          "description" : "Outcome of the Procurement Procedure for a given Lot",
-          "_label" : "group|name|ND-LotResult",
+          "description" : "Statistics about Review Requests (number and code)",
+          "_label" : "group|name|ND-ReviewRequestsStatistics",
           "_repeatable" : true,
           "content" : [ {
             "id" : "BT-636-LotResult",
@@ -3025,10 +3025,10 @@
         }, {
           "id" : "GR-LotResult-ReceivedSubmissions",
           "contentType" : "group",
-          "nodeId" : "ND-LotResult",
+          "nodeId" : "ND-ReceivedSubmissions",
           "displayType" : "GROUP",
-          "description" : "Outcome of the Procurement Procedure for a given Lot",
-          "_label" : "group|name|ND-LotResult",
+          "description" : "Container for Received Submissions Statististics Numeric value and associated code.",
+          "_label" : "group|name|ND-ReceivedSubmissions",
           "_repeatable" : true,
           "content" : [ {
             "id" : "BT-760-LotResult",

--- a/notice-types/30.json
+++ b/notice-types/30.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "30",
   "metadata" : [ {
@@ -2898,10 +2898,10 @@
         }, {
           "id" : "GR-LotResult-ReviewRequests",
           "contentType" : "group",
-          "nodeId" : "ND-LotResult",
+          "nodeId" : "ND-ReviewRequestsStatistics",
           "displayType" : "GROUP",
-          "description" : "Outcome of the Procurement Procedure for a given Lot",
-          "_label" : "group|name|ND-LotResult",
+          "description" : "Statistics about Review Requests (number and code)",
+          "_label" : "group|name|ND-ReviewRequestsStatistics",
           "_repeatable" : true,
           "content" : [ {
             "id" : "BT-636-LotResult",
@@ -3038,10 +3038,10 @@
         }, {
           "id" : "GR-LotResult-ReceivedSubmissions",
           "contentType" : "group",
-          "nodeId" : "ND-LotResult",
+          "nodeId" : "ND-ReceivedSubmissions",
           "displayType" : "GROUP",
-          "description" : "Outcome of the Procurement Procedure for a given Lot",
-          "_label" : "group|name|ND-LotResult",
+          "description" : "Container for Received Submissions Statististics Numeric value and associated code.",
+          "_label" : "group|name|ND-ReceivedSubmissions",
           "_repeatable" : true,
           "content" : [ {
             "id" : "BT-760-LotResult",

--- a/notice-types/31.json
+++ b/notice-types/31.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "31",
   "metadata" : [ {
@@ -2859,10 +2859,10 @@
         }, {
           "id" : "GR-LotResult-ReviewRequests",
           "contentType" : "group",
-          "nodeId" : "ND-LotResult",
+          "nodeId" : "ND-ReviewRequestsStatistics",
           "displayType" : "GROUP",
-          "description" : "Outcome of the Procurement Procedure for a given Lot",
-          "_label" : "group|name|ND-LotResult",
+          "description" : "Statistics about Review Requests (number and code)",
+          "_label" : "group|name|ND-ReviewRequestsStatistics",
           "_repeatable" : true,
           "content" : [ {
             "id" : "BT-636-LotResult",
@@ -2999,10 +2999,10 @@
         }, {
           "id" : "GR-LotResult-ReceivedSubmissions",
           "contentType" : "group",
-          "nodeId" : "ND-LotResult",
+          "nodeId" : "ND-ReceivedSubmissions",
           "displayType" : "GROUP",
-          "description" : "Outcome of the Procurement Procedure for a given Lot",
-          "_label" : "group|name|ND-LotResult",
+          "description" : "Container for Received Submissions Statististics Numeric value and associated code.",
+          "_label" : "group|name|ND-ReceivedSubmissions",
           "_repeatable" : true,
           "content" : [ {
             "id" : "BT-760-LotResult",

--- a/notice-types/32.json
+++ b/notice-types/32.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "32",
   "metadata" : [ {
@@ -2345,10 +2345,10 @@
         }, {
           "id" : "GR-LotResult-ReviewRequests",
           "contentType" : "group",
-          "nodeId" : "ND-LotResult",
+          "nodeId" : "ND-ReviewRequestsStatistics",
           "displayType" : "GROUP",
-          "description" : "Outcome of the Procurement Procedure for a given Lot",
-          "_label" : "group|name|ND-LotResult",
+          "description" : "Statistics about Review Requests (number and code)",
+          "_label" : "group|name|ND-ReviewRequestsStatistics",
           "_repeatable" : true,
           "content" : [ {
             "id" : "BT-636-LotResult",
@@ -2485,10 +2485,10 @@
         }, {
           "id" : "GR-LotResult-ReceivedSubmissions",
           "contentType" : "group",
-          "nodeId" : "ND-LotResult",
+          "nodeId" : "ND-ReceivedSubmissions",
           "displayType" : "GROUP",
-          "description" : "Outcome of the Procurement Procedure for a given Lot",
-          "_label" : "group|name|ND-LotResult",
+          "description" : "Container for Received Submissions Statististics Numeric value and associated code.",
+          "_label" : "group|name|ND-ReceivedSubmissions",
           "_repeatable" : true,
           "content" : [ {
             "id" : "BT-760-LotResult",

--- a/notice-types/33.json
+++ b/notice-types/33.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "33",
   "metadata" : [ {
@@ -2699,10 +2699,10 @@
         }, {
           "id" : "GR-LotResult-ReviewRequests",
           "contentType" : "group",
-          "nodeId" : "ND-LotResult",
+          "nodeId" : "ND-ReviewRequestsStatistics",
           "displayType" : "GROUP",
-          "description" : "Outcome of the Procurement Procedure for a given Lot",
-          "_label" : "group|name|ND-LotResult",
+          "description" : "Statistics about Review Requests (number and code)",
+          "_label" : "group|name|ND-ReviewRequestsStatistics",
           "_repeatable" : true,
           "content" : [ {
             "id" : "BT-636-LotResult",
@@ -2839,10 +2839,10 @@
         }, {
           "id" : "GR-LotResult-ReceivedSubmissions",
           "contentType" : "group",
-          "nodeId" : "ND-LotResult",
+          "nodeId" : "ND-ReceivedSubmissions",
           "displayType" : "GROUP",
-          "description" : "Outcome of the Procurement Procedure for a given Lot",
-          "_label" : "group|name|ND-LotResult",
+          "description" : "Container for Received Submissions Statististics Numeric value and associated code.",
+          "_label" : "group|name|ND-ReceivedSubmissions",
           "_repeatable" : true,
           "content" : [ {
             "id" : "BT-760-LotResult",

--- a/notice-types/34.json
+++ b/notice-types/34.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "34",
   "metadata" : [ {
@@ -2717,10 +2717,10 @@
         }, {
           "id" : "GR-LotResult-ReviewRequests",
           "contentType" : "group",
-          "nodeId" : "ND-LotResult",
+          "nodeId" : "ND-ReviewRequestsStatistics",
           "displayType" : "GROUP",
-          "description" : "Outcome of the Procurement Procedure for a given Lot",
-          "_label" : "group|name|ND-LotResult",
+          "description" : "Statistics about Review Requests (number and code)",
+          "_label" : "group|name|ND-ReviewRequestsStatistics",
           "_repeatable" : true,
           "content" : [ {
             "id" : "BT-636-LotResult",
@@ -2857,10 +2857,10 @@
         }, {
           "id" : "GR-LotResult-ReceivedSubmissions",
           "contentType" : "group",
-          "nodeId" : "ND-LotResult",
+          "nodeId" : "ND-ReceivedSubmissions",
           "displayType" : "GROUP",
-          "description" : "Outcome of the Procurement Procedure for a given Lot",
-          "_label" : "group|name|ND-LotResult",
+          "description" : "Container for Received Submissions Statististics Numeric value and associated code.",
+          "_label" : "group|name|ND-ReceivedSubmissions",
           "_repeatable" : true,
           "content" : [ {
             "id" : "BT-760-LotResult",

--- a/notice-types/35.json
+++ b/notice-types/35.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "35",
   "metadata" : [ {
@@ -2332,10 +2332,10 @@
         }, {
           "id" : "GR-LotResult-ReviewRequests",
           "contentType" : "group",
-          "nodeId" : "ND-LotResult",
+          "nodeId" : "ND-ReviewRequestsStatistics",
           "displayType" : "GROUP",
-          "description" : "Outcome of the Procurement Procedure for a given Lot",
-          "_label" : "group|name|ND-LotResult",
+          "description" : "Statistics about Review Requests (number and code)",
+          "_label" : "group|name|ND-ReviewRequestsStatistics",
           "_repeatable" : true,
           "content" : [ {
             "id" : "BT-636-LotResult",
@@ -2472,10 +2472,10 @@
         }, {
           "id" : "GR-LotResult-ReceivedSubmissions",
           "contentType" : "group",
-          "nodeId" : "ND-LotResult",
+          "nodeId" : "ND-ReceivedSubmissions",
           "displayType" : "GROUP",
-          "description" : "Outcome of the Procurement Procedure for a given Lot",
-          "_label" : "group|name|ND-LotResult",
+          "description" : "Container for Received Submissions Statististics Numeric value and associated code.",
+          "_label" : "group|name|ND-ReceivedSubmissions",
           "_repeatable" : true,
           "content" : [ {
             "id" : "BT-760-LotResult",

--- a/notice-types/36.json
+++ b/notice-types/36.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "36",
   "metadata" : [ {
@@ -2076,10 +2076,10 @@
         }, {
           "id" : "GR-LotResult-ReviewRequests",
           "contentType" : "group",
-          "nodeId" : "ND-LotResult",
+          "nodeId" : "ND-ReviewRequestsStatistics",
           "displayType" : "GROUP",
-          "description" : "Outcome of the Procurement Procedure for a given Lot",
-          "_label" : "group|name|ND-LotResult",
+          "description" : "Statistics about Review Requests (number and code)",
+          "_label" : "group|name|ND-ReviewRequestsStatistics",
           "_repeatable" : true,
           "content" : [ {
             "id" : "BT-636-LotResult",
@@ -2184,10 +2184,10 @@
         }, {
           "id" : "GR-LotResult-ReceivedSubmissions",
           "contentType" : "group",
-          "nodeId" : "ND-LotResult",
+          "nodeId" : "ND-ReceivedSubmissions",
           "displayType" : "GROUP",
-          "description" : "Outcome of the Procurement Procedure for a given Lot",
-          "_label" : "group|name|ND-LotResult",
+          "description" : "Container for Received Submissions Statististics Numeric value and associated code.",
+          "_label" : "group|name|ND-ReceivedSubmissions",
           "_repeatable" : true,
           "content" : [ {
             "id" : "BT-760-LotResult",

--- a/notice-types/37.json
+++ b/notice-types/37.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "37",
   "metadata" : [ {
@@ -2082,10 +2082,10 @@
         }, {
           "id" : "GR-LotResult-ReviewRequests",
           "contentType" : "group",
-          "nodeId" : "ND-LotResult",
+          "nodeId" : "ND-ReviewRequestsStatistics",
           "displayType" : "GROUP",
-          "description" : "Outcome of the Procurement Procedure for a given Lot",
-          "_label" : "group|name|ND-LotResult",
+          "description" : "Statistics about Review Requests (number and code)",
+          "_label" : "group|name|ND-ReviewRequestsStatistics",
           "_repeatable" : true,
           "content" : [ {
             "id" : "BT-636-LotResult",
@@ -2190,10 +2190,10 @@
         }, {
           "id" : "GR-LotResult-ReceivedSubmissions",
           "contentType" : "group",
-          "nodeId" : "ND-LotResult",
+          "nodeId" : "ND-ReceivedSubmissions",
           "displayType" : "GROUP",
-          "description" : "Outcome of the Procurement Procedure for a given Lot",
-          "_label" : "group|name|ND-LotResult",
+          "description" : "Container for Received Submissions Statististics Numeric value and associated code.",
+          "_label" : "group|name|ND-ReceivedSubmissions",
           "_repeatable" : true,
           "content" : [ {
             "id" : "BT-760-LotResult",

--- a/notice-types/38.json
+++ b/notice-types/38.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "38",
   "metadata" : [ {
@@ -1530,10 +1530,10 @@
         }, {
           "id" : "GR-LotResult-ReviewRequests",
           "contentType" : "group",
-          "nodeId" : "ND-LotResult",
+          "nodeId" : "ND-ReviewRequestsStatistics",
           "displayType" : "GROUP",
-          "description" : "Outcome of the Procurement Procedure for a given Lot",
-          "_label" : "group|name|ND-LotResult",
+          "description" : "Statistics about Review Requests (number and code)",
+          "_label" : "group|name|ND-ReviewRequestsStatistics",
           "_repeatable" : true,
           "content" : [ {
             "id" : "BT-636-LotResult",

--- a/notice-types/39.json
+++ b/notice-types/39.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "39",
   "metadata" : [ {
@@ -1530,10 +1530,10 @@
         }, {
           "id" : "GR-LotResult-ReviewRequests",
           "contentType" : "group",
-          "nodeId" : "ND-LotResult",
+          "nodeId" : "ND-ReviewRequestsStatistics",
           "displayType" : "GROUP",
-          "description" : "Outcome of the Procurement Procedure for a given Lot",
-          "_label" : "group|name|ND-LotResult",
+          "description" : "Statistics about Review Requests (number and code)",
+          "_label" : "group|name|ND-ReviewRequestsStatistics",
           "_repeatable" : true,
           "content" : [ {
             "id" : "BT-636-LotResult",

--- a/notice-types/40.json
+++ b/notice-types/40.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "40",
   "metadata" : [ {
@@ -1281,10 +1281,10 @@
         }, {
           "id" : "GR-LotResult-ReviewRequests",
           "contentType" : "group",
-          "nodeId" : "ND-LotResult",
+          "nodeId" : "ND-ReviewRequestsStatistics",
           "displayType" : "GROUP",
-          "description" : "Outcome of the Procurement Procedure for a given Lot",
-          "_label" : "group|name|ND-LotResult",
+          "description" : "Statistics about Review Requests (number and code)",
+          "_label" : "group|name|ND-ReviewRequestsStatistics",
           "_repeatable" : true,
           "content" : [ {
             "id" : "BT-636-LotResult",

--- a/notice-types/7.json
+++ b/notice-types/7.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "7",
   "metadata" : [ {
@@ -1302,17 +1302,25 @@
           "description" : "Tenderer Legal Form Description",
           "_label" : "field|name|BT-76-Lot"
         }, {
-          "id" : "BT-771-Lot",
-          "contentType" : "field",
-          "displayType" : "COMBOBOX",
-          "description" : "Late Tenderer Information",
-          "_label" : "field|name|BT-771-Lot"
-        }, {
-          "id" : "BT-772-Lot",
-          "contentType" : "field",
-          "displayType" : "TEXTAREA",
-          "description" : "Late Tenderer Information Description",
-          "_label" : "field|name|BT-772-Lot"
+          "id" : "GR-LateTendererInformation",
+          "contentType" : "group",
+          "nodeId" : "ND-LateTendererInformation",
+          "displayType" : "GROUP",
+          "description" : "Information about late provision of information by the tenderer (possibility and description of the information)",
+          "_label" : "group|name|ND-LateTendererInformation",
+          "content" : [ {
+            "id" : "BT-771-Lot",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "Late Tenderer Information",
+            "_label" : "field|name|BT-771-Lot"
+          }, {
+            "id" : "BT-772-Lot",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Late Tenderer Information Description",
+            "_label" : "field|name|BT-772-Lot"
+          } ]
         }, {
           "id" : "GR-ReservedParticipation",
           "contentType" : "group",

--- a/notice-types/8.json
+++ b/notice-types/8.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "8",
   "metadata" : [ {
@@ -1308,17 +1308,25 @@
           "description" : "Tenderer Legal Form Description",
           "_label" : "field|name|BT-76-Lot"
         }, {
-          "id" : "BT-771-Lot",
-          "contentType" : "field",
-          "displayType" : "COMBOBOX",
-          "description" : "Late Tenderer Information",
-          "_label" : "field|name|BT-771-Lot"
-        }, {
-          "id" : "BT-772-Lot",
-          "contentType" : "field",
-          "displayType" : "TEXTAREA",
-          "description" : "Late Tenderer Information Description",
-          "_label" : "field|name|BT-772-Lot"
+          "id" : "GR-LateTendererInformation",
+          "contentType" : "group",
+          "nodeId" : "ND-LateTendererInformation",
+          "displayType" : "GROUP",
+          "description" : "Information about late provision of information by the tenderer (possibility and description of the information)",
+          "_label" : "group|name|ND-LateTendererInformation",
+          "content" : [ {
+            "id" : "BT-771-Lot",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "Late Tenderer Information",
+            "_label" : "field|name|BT-771-Lot"
+          }, {
+            "id" : "BT-772-Lot",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Late Tenderer Information Description",
+            "_label" : "field|name|BT-772-Lot"
+          } ]
         }, {
           "id" : "GR-ReservedParticipation",
           "contentType" : "group",

--- a/notice-types/9.json
+++ b/notice-types/9.json
@@ -2,8 +2,8 @@
   "ublVersion" : "2.3",
   "sdkVersion" : "1.5.0",
   "metadataDatabase" : {
-    "version" : "1.5.0",
-    "createdOn" : "2022-12-14T11:00:00"
+    "version" : "1.5.12",
+    "createdOn" : "2023-01-12T09:49:36"
   },
   "noticeId" : "9",
   "metadata" : [ {
@@ -1295,17 +1295,25 @@
           "description" : "Tenderer Legal Form Description",
           "_label" : "field|name|BT-76-Lot"
         }, {
-          "id" : "BT-771-Lot",
-          "contentType" : "field",
-          "displayType" : "COMBOBOX",
-          "description" : "Late Tenderer Information",
-          "_label" : "field|name|BT-771-Lot"
-        }, {
-          "id" : "BT-772-Lot",
-          "contentType" : "field",
-          "displayType" : "TEXTAREA",
-          "description" : "Late Tenderer Information Description",
-          "_label" : "field|name|BT-772-Lot"
+          "id" : "GR-LateTendererInformation",
+          "contentType" : "group",
+          "nodeId" : "ND-LateTendererInformation",
+          "displayType" : "GROUP",
+          "description" : "Information about late provision of information by the tenderer (possibility and description of the information)",
+          "_label" : "group|name|ND-LateTendererInformation",
+          "content" : [ {
+            "id" : "BT-771-Lot",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "Late Tenderer Information",
+            "_label" : "field|name|BT-771-Lot"
+          }, {
+            "id" : "BT-772-Lot",
+            "contentType" : "field",
+            "displayType" : "TEXTAREA",
+            "description" : "Late Tenderer Information Description",
+            "_label" : "field|name|BT-772-Lot"
+          } ]
         }, {
           "id" : "GR-ReservedParticipation",
           "contentType" : "group",

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>eu.europa.ted.eforms</groupId>
   <artifactId>eforms-sdk</artifactId>
-  <version>1.5.0</version>
+  <version>1.5.1</version>
   <packaging>jar</packaging>
 
   <name>eForms SDK</name>

--- a/translations/code_en.xml
+++ b/translations/code_en.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties>
-<comment>code in English. File generated from metadata database version 1.5.0 created on the 2022-12-14T11:00</comment>
+<comment>code in English. File generated from metadata database version 1.5.12 created on the 2023-01-12T09:49:36</comment>
 <entry key="code|name|accessibility.inc">Accessibility criteria for persons with disabilities are included</entry>
 <entry key="code|name|accessibility.n-inc">Accessibility criteria for persons with disabilities are not included because the procurement is not intended for use by natural persons</entry>
 <entry key="code|name|accessibility.n-inc-just">Accessibility criteria for persons with disabilities are not included with the following justification</entry>
@@ -10385,8 +10385,8 @@
 <entry key="code|name|innovative-acquisition.mar-nov">The procured works, supplies or services are novel or significantly improved compared to other works, supplies, or services already on the market.</entry>
 <entry key="code|name|innovative-acquisition.org-nov">The procured works, supplies or services are novel for the organisation.</entry>
 <entry key="code|name|innovative-acquisition.other">Other</entry>
-<entry key="code|name|innovative-acquisition.proc-innov"></entry>
-<entry key="code|name|innovative-acquisition.prod-innov"></entry>
+<entry key="code|name|innovative-acquisition.proc-innov">The procured works, supplies, or services entail process innovation.</entry>
+<entry key="code|name|innovative-acquisition.prod-innov">The procured works, supplies, or services entail product innovation.</entry>
 <entry key="code|name|innovative-acquisition.rd-act">The procured works, supplies or services involve research and development activities.</entry>
 <entry key="code|name|irregularity-type.ab-low">Unjustified rejection of abnormally low tenders</entry>
 <entry key="code|name|irregularity-type.ar-split">Artificial splitting of contracts</entry>

--- a/translations/group_en.xml
+++ b/translations/group_en.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties>
-<comment>group in English. File generated from metadata database version 1.5.0 created on the 2022-12-14T11:00</comment>
+<comment>group in English. File generated from metadata database version 1.5.12 created on the 2023-01-12T09:49:36</comment>
 <entry key="group|name|GR-132001">Information about Recurrence</entry>
 <entry key="group|name|GR-Business-Address">Address</entry>
 <entry key="group|name|GR-Business-Contact">Contact</entry>
@@ -243,6 +243,7 @@
 <entry key="group|name|ND-GroupMaximalValueIdentifierUnpublish">Not Immediately Published (GroupMaximalValueIdentifier)</entry>
 <entry key="group|name|ND-GroupMaximumValueUnpublish">Not Immediately Published (GroupMaximumValue)</entry>
 <entry key="group|name|ND-GroupReestimatedValueUnpublish">Not Immediately Published (GroupReestimatedValue)</entry>
+<entry key="group|name|ND-LateTendererInformation">Information about late provision of information by the tenderer (possibility and description of the information)</entry>
 <entry key="group|name|ND-LocalLegalBasisNoID">Legislation impacting the procurement and for which no ID is known</entry>
 <entry key="group|name|ND-LocalLegalBasisWithID">Other legal basis with an identifier</entry>
 <entry key="group|name|ND-Lot">Information about the lot</entry>
@@ -304,6 +305,8 @@
 <entry key="group|name|ND-ProcedureTypeUnpublish">Not Immediately Published (Procedure Type)</entry>
 <entry key="group|name|ND-ReceivedSubmissionCountUnpublish">Not Immediately Published (ReceivedSubmissionCount)</entry>
 <entry key="group|name|ND-ReceivedSubmissionTypeUnpublish">Not Immediately Published (ReceivedSubmissionType)</entry>
+<entry key="group|name|ND-ReceivedSubmissions">Container for Received Submissions Statististics Numeric value and associated code.</entry>
+<entry key="group|name|ND-ReviewRequestsStatistics">Statistics about Review Requests (number and code)</entry>
 <entry key="group|name|ND-ReviewRequestsStatisticsCountUnpublish">Not Immediately Published (RevewRequests irregularity count )</entry>
 <entry key="group|name|ND-ReviewRequestsStatisticsTypeUnpublish">Not Immediately Published (RevewRequests irregularity type )</entry>
 <entry key="group|name|ND-RewardsPenalties">Information on rewards and penalties</entry>


### PR DESCRIPTION
This contains the only changes in SDK 1.5.1, including release notes and version bumps.

This should be merged only when the release candidate has been checked.