### PR TITLE
avoid storing full path into -sources.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.build.outputTimestamp>1</project.build.outputTimestamp>
+    <project.build.outputTimestamp>1674460454</project.build.outputTimestamp>
 
     <version.eforms-sdk-analyzer>1.5.0-SNAPSHOT</version.eforms-sdk-analyzer>
 
@@ -63,7 +63,7 @@
     <resources>
       <resource>
         <directory>${basedir}</directory>
-        <targetPath>${project.build.outputDirectory}/eforms-sdk</targetPath>
+        <targetPath>eforms-sdk</targetPath>
         <excludes>
           <exclude>**/.antlr/</exclude>
           <exclude>.classpath</exclude>


### PR DESCRIPTION
small issue found when rebuilding release 1.5.1 https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/eu/europa/ted/eforms/eforms-sdk/README.md