### PR TITLE
Bugfix/TEDEFO-2311-like-pattern-expression-and-multilingual-text-fields

### DIFF
--- a/efx-grammar/Efx.g4
+++ b/efx-grammar/Efx.g4
@@ -191,6 +191,7 @@ booleanExpression
     | timeExpression        Comparison lateBoundScalar                          # ppTimeToLateBoundComparison
     | durationExpression    Comparison lateBoundScalar                          # ppDurationToLateBoundComparison
     | lateBoundScalar       Comparison lateBoundScalar                          # ppFieldValueComparison
+    | lateBoundExpression   Not? Like pattern=STRING                            # pplikePatternCondition
     | lateBoundExpression   Is Not? Empty                                       # ppLateBoundEmptinessCondition
     | stringExpression      Not? In lateBoundSequence                           # ppStringInLateBoundListCondition
     | numericExpression     Not? In lateBoundSequence                           # ppNumberInLateBoundListCondition

--- a/efx-grammar/Efx.g4
+++ b/efx-grammar/Efx.g4
@@ -476,13 +476,15 @@ numericFunction
     ;
 
 stringFunction
-    : SubstringFunction     OpenParenthesis (stringExpression   | lateBoundScalar)   Comma (start=numericExpression | lateBoundScalar) (Comma (length=numericExpression | lateBoundScalar))? CloseParenthesis       # substringFunction
-    | StringFunction        OpenParenthesis (numericExpression  | lateBoundScalar)   CloseParenthesis                                                                                                               # toStringFunction
-    | ConcatFunction        OpenParenthesis (stringExpression   | lateBoundScalar)  (Comma (stringExpression        | lateBoundScalar))* CloseParenthesis                                                           # concatFunction
-    | StringJoinFunction    OpenParenthesis (stringSequence     | lateBoundSequence) Comma (stringExpression        | lateBoundScalar)   CloseParenthesis                                                           # stringJoinFunction
-    | FormatNumberFunction  OpenParenthesis (numericExpression  | lateBoundScalar)  (Comma (format=stringExpression | lateBoundScalar))? CloseParenthesis                                                           # formatNumberFunction
-    | UpperCaseFunction     OpenParenthesis (stringExpression   | lateBoundScalar)   CloseParenthesis                                                                                                               # upperCaseFunction
-    | LowerCaseFunction     OpenParenthesis (stringExpression   | lateBoundScalar)   CloseParenthesis                                                                                                               # lowerCaseFunction
+    : SubstringFunction              OpenParenthesis (stringExpression   | lateBoundScalar)   Comma (start=numericExpression | lateBoundScalar) (Comma (length=numericExpression | lateBoundScalar))? CloseParenthesis   # substringFunction
+    | StringFunction                 OpenParenthesis (numericExpression  | lateBoundScalar)   CloseParenthesis                                                                                                           # toStringFunction
+    | ConcatFunction                 OpenParenthesis (stringExpression   | lateBoundScalar)  (Comma (stringExpression        | lateBoundScalar))* CloseParenthesis                                                       # concatFunction
+    | StringJoinFunction             OpenParenthesis (stringSequence     | lateBoundSequence) Comma (stringExpression        | lateBoundScalar)   CloseParenthesis                                                       # stringJoinFunction
+    | FormatNumberFunction           OpenParenthesis (numericExpression  | lateBoundScalar)  (Comma (format=stringExpression | lateBoundScalar))? CloseParenthesis                                                       # formatNumberFunction
+    | UpperCaseFunction              OpenParenthesis (stringExpression   | lateBoundScalar)   CloseParenthesis                                                                                                           # upperCaseFunction
+    | LowerCaseFunction              OpenParenthesis (stringExpression   | lateBoundScalar)   CloseParenthesis                                                                                                           # lowerCaseFunction
+    | PreferredLanguageFunction      OpenParenthesis simpleFieldReference                     CloseParenthesis                                                                                                           # preferredLanguageFunction
+    | PreferredLanguageTextFunction  OpenParenthesis simpleFieldReference                     CloseParenthesis                                                                                                           # preferredLanguageTextFunction
     ;
 
 

--- a/efx-grammar/Efx.g4
+++ b/efx-grammar/Efx.g4
@@ -417,8 +417,8 @@ contextVariableDeclaration:     ContextType Colon Variable;
 
 
 pathFromReference
-    : fieldReference
-    | attributeReference
+    : attributeReference
+    |fieldReference 
     ;
 
 contextFieldSpecifier: field=fieldContext ColonColon;
@@ -527,9 +527,9 @@ lateBoundSequence
 lateBoundSequenceFromIteration: For iteratorList Return lateBoundScalar;
 
 lateBoundSequenceReference
-    : fieldReference                                    # sequenceFromFieldReference
-    | attributeReference                                # sequenceFromAttributeReference 
-    | variableReference                                 # untypedSequenceVariableExpression
+    : attributeReference        # sequenceFromAttributeReference 
+    | fieldReference            # sequenceFromFieldReference
+    | variableReference         # untypedSequenceVariableExpression
     ;
 
 lateBoundScalar
@@ -540,9 +540,9 @@ lateBoundScalar
     ;
 
 lateBoundScalarReference
-    : fieldReference        # scalarFromFieldReference
-    | attributeReference    # scalarFromAttributeReference 
-    | variableReference                                                                 # untypedVariableExpression
+    : attributeReference        # scalarFromAttributeReference 
+    | fieldReference            # scalarFromFieldReference
+    | variableReference         # untypedVariableExpression
     ;
 
 variableReference: Variable;

--- a/efx-grammar/EfxLexer.g4
+++ b/efx-grammar/EfxLexer.g4
@@ -287,6 +287,8 @@ UnionFunction: 'value-union';
 IntersectFunction: 'value-intersect';
 ExceptFunction: 'value-except';
 SequenceEqualFunction: 'sequence-equal';
+PreferredLanguageFunction: 'preferred-language';
+PreferredLanguageTextFunction: 'preferred-language-text';
 
 // Effective order of precedence is the order of declaration. 
 // Duration tokens must take precedence over Identifier tokens to avoid using delimiters like quotes.


### PR DESCRIPTION
Fixes a bug and adds two i18n functions for mutilingual text fields. 