### PR TITLE
Adding new element for Review Technical ID (TEDEFO-3045)

### DIFF
--- a/schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd
+++ b/schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd
@@ -126,6 +126,7 @@
 	</xsd:complexType>
 	<xsd:complexType name="AppealStatusType">
 		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
 			<xsd:element ref="cbc:Date" minOccurs="1" maxOccurs="1"/>
 			<xsd:element ref="cbc:Title" minOccurs="1" maxOccurs="unbounded"/>
 			<xsd:element ref="cbc:Description" minOccurs="1" maxOccurs="unbounded"/>


### PR DESCRIPTION
definition of a new element cbc:ID to be used for the Review Technical Identifier.

NB: Cardinality of some Review elements could be reviewed with a minimum of 0 instead of 1. Not yet done as not yet used.