### PR TITLE
Add workflow to run schematron benchmark

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+      packages: read
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,11 +1,7 @@
 name: Benchmark Schematron rules with the SDK Analyzer
 
-on:
-  push:
-  pull_request:
-
-  # Allows to run this workflow manually from the Actions tab
-  workflow_dispatch:
+# Allows to also run this workflow manually from the Actions tab
+on: [push, pull_request, workflow_dispatch]
 
 permissions:
   # Contents permission needed to create a commit comment

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,16 +3,14 @@ name: Benchmark Schematron rules with the SDK Analyzer
 # Allows to also run this workflow manually from the Actions tab
 on: [push, pull_request, workflow_dispatch]
 
-# Contents permission needed to create a commit comment
-permissions: write-all
-
 jobs:
   benchmark:
     name: Run Schematron benchmark
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      packages: write
+      # Contents permission needed to create a commit comment
+      contents: write
+      packages: read
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,52 @@
+name: Benchmark Schematron rules with the SDK Analyzer
+
+on:
+  push:
+  pull_request:
+
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    name: Run Schematron benchmark
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Run benchmark
+        run: mvn clean install -Pbenchmark --no-transfer-progress -s .github/workflows/settings.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Download previous benchmark result from cache (if exists)
+      - name: Download previous benchmark data
+        uses: actions/cache@v4
+        with:
+          path: ./cache
+          key: ${{ runner.os }}-benchmark
+
+      - name: Process benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: JMH Benchmark
+          tool: 'jmh'
+          output-file-path: jmh-result.json
+          external-data-json-path: ./cache/benchmark-data.json
+          # Alert if new results are significantly worse than previous results
+          alert-threshold: "120%"
+          # Do not mark the workflow as failed if an alert happens
+          fail-on-alert: false
+          # Add a comment on the commit that caused the alert
+          comment-on-alert: true
+          # GitHub API token to make a commit comment
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -43,9 +43,9 @@ jobs:
           output-file-path: jmh-result.json
           external-data-json-path: ./cache/benchmark-data.json
           # Alert if new results are significantly worse than previous results
-          alert-threshold: "120%"
-          # Do not mark the workflow as failed if an alert happens
-          fail-on-alert: false
+          alert-threshold: "110%"
+          # Mark the workflow as failed if an alert happens
+          fail-on-alert: true
           # Add a comment on the commit that caused the alert
           comment-on-alert: true
           # GitHub API token to make a commit comment

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,6 +7,10 @@ on:
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  # Contents permission needed to create a commit comment
+  contents: write
+
 jobs:
   benchmark:
     name: Run Schematron benchmark

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,9 +3,8 @@ name: Benchmark Schematron rules with the SDK Analyzer
 # Allows to also run this workflow manually from the Actions tab
 on: [push, pull_request, workflow_dispatch]
 
-permissions:
-  # Contents permission needed to create a commit comment
-  contents: write
+# Contents permission needed to create a commit comment
+permissions: write-all
 
 jobs:
   benchmark:

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,42 @@
                     <argument>eu.europa.ted.eforms.sdk.analysis.Application</argument>
                     <argument>${project.basedir}</argument>
                   </arguments>
-                  <classpath/>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>benchmark</id>
+      <dependencies>
+        <dependency>
+          <groupId>eu.europa.ted.eforms</groupId>
+          <artifactId>eforms-sdk-analyzer</artifactId>
+          <version>${version.eforms-sdk-analyzer}</version>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>validate</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>java</executable>
+                  <arguments>
+                    <argument>-classpath</argument>
+                    <classpath/>
+                    <argument>eu.europa.ted.eforms.sdk.analysis.Application</argument>
+                    <argument>${project.basedir}</argument>
+                    <argument>benchmark</argument>
+                  </arguments>
                 </configuration>
               </execution>
             </executions>

--- a/schematrons/dynamic/validation-stage-5m.sch
+++ b/schematrons/dynamic/validation-stage-5m.sch
@@ -11,8 +11,7 @@
 	<let name="global-res-ids" value="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/cbc:ID" />
 	<let name="global-con-ids" value="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/cbc:ID"/>
 	<let name="global-con-business-ids" value="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:ContractReference/cbc:ID"/>
-	<let name="global-ten-ids" value="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/
-	efac:LotTender/cbc:ID"/>
+	<let name="global-ten-ids" value="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID"/>
 	<let name="global-tpa-ids" value="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/cbc:ID"/>
 	
 	<!-- Variable for references to identifiers -->
@@ -76,7 +75,7 @@
 		<assert id="BR-OPT-00301-1410" role="ERROR" diagnostics="ND-LotResult_OPT-301-LotResult-Financing" test="(every $financing in cac:FinancingParty/cac:PartyIdentification/cbc:ID/normalize-space(text()) satisfies ($financing = $global-org-ids)) or not(cac:FinancingParty/cac:PartyIdentification/cbc:ID)">rule|text|BR-OPT-00301-1410</assert>
 		<assert id="BR-OPT-00301-1414" role="ERROR" diagnostics="ND-LotResult_OPT-301-LotResult-Paying" test="(every $payer in cac:PayerParty/cac:PartyIdentification/cbc:ID/normalize-space(text()) satisfies ($payer = $global-org-ids)) or not(cac:PayerParty/cac:PartyIdentification/cbc:ID)">rule|text|BR-OPT-00301-1414</assert>
 		<assert id="BR-OPT-00315-0100" role="ERROR" diagnostics="ND-LotResult_OPT-315-LotResult" test="(every $contract in efac:SettledContract/cbc:ID/normalize-space(text()) satisfies ($contract = $global-con-ids)) or not(efac:SettledContract/cbc:ID)">rule|text|BR-OPT-00315-0100</assert>
-		<assert id="BR-OPT-00320-0100" role="ERROR" diagnostics="ND-LotResult_OPT-320-LotResult" test="(every $tender in efac:LotTender/cbc:ID/normalize-space(text()) satisfies ($tender = $global-ten-ids)) or not(efac:LotTender/cbc:ID)">rule|text|BR-OPT-00320-0100</assert>
+		<assert id="BR-OPT-00320-0100" role="ERROR" diagnostics="ND-LotResult_OPT-320-LotResult" test="(every $tender in efac:LotTender/cbc:ID/normalize-space(text()) satisfies ($tender = /*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID)) or not(efac:LotTender/cbc:ID)">rule|text|BR-OPT-00320-0100</assert>
 	</rule>
 
 	<rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract">

--- a/schematrons/dynamic/validation-stage-5m.sch
+++ b/schematrons/dynamic/validation-stage-5m.sch
@@ -83,24 +83,4 @@
 		<assert id="BR-OPT-00300-0252" role="ERROR" diagnostics="ND-SettledContract_OPT-300-Contract-Signatory" test="(every $signatory in cac:SignatoryParty/cac:PartyIdentification/cbc:ID/normalize-space(text()) satisfies ($signatory = $global-org-ids)) or not(cac:SignatoryParty/cac:PartyIdentification/cbc:ID)">rule|text|BR-OPT-00300-0252</assert>
 	</rule>
 
-	<rule context="/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cbc:ID">
-		<assert id="BR-BT-00022-0241-slow" role="ERROR" test="count(for $x in ., $y in /*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cbc:ID[. = $x] return $y) = 1">rule|text|BR-BT-00022-0241</assert>
-	</rule>
-
-	<rule context="/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cbc:ID">
-		<assert id="BR-BT-00137-0201-slow" role="ERROR" test="count(for $x in ., $y in /*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cbc:ID[. = $x] return $y) = 1">rule|text|BR-BT-00137-0201</assert>
-	</rule>
-		
-	<rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID">
-		<assert id="BR-OPT-00321-0100-slow" role="ERROR" test="count(for $x in ., $y in /*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID[. = $x] return $y) = 1">rule|text|BR-OPT-00321-0100</assert>
-	</rule>
-
-	<rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:ContractReference/cbc:ID">
-		<assert id="BR-BT-00150-0101-slow" role="ERROR" test="count(for $x in ., $y in /*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:ContractReference/cbc:ID[. = $x] return $y) = 1">rule|text|BR-BT-00150-0101</assert>
-	</rule>
-
-	<rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/cbc:ID">
-		<assert id="BR-OPT-00210-0100-slow" role="ERROR" test="count(for $x in ., $y in /*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/cbc:ID[. = $x] return $y) = 1">rule|text|BR-OPT-00210-0100</assert>
-	</rule>
-
 </pattern>

--- a/schematrons/dynamic/validation-stage-5m.sch
+++ b/schematrons/dynamic/validation-stage-5m.sch
@@ -28,7 +28,7 @@
 	<let name="global-res-ids-duplicates" value="for $val in distinct-values($global-res-ids) return $val[count($global-res-ids[. = $val]) > 1]"/>
 	<let name="global-con-ids-duplicates" value="for $val in distinct-values($global-con-ids) return $val[count($global-con-ids[. = $val]) > 1]"/>
 	<let name="global-con-business-ids-duplicates" value="for $val in distinct-values($global-con-business-ids) return $val[count($global-con-business-ids[. = $val]) > 1]"/>
-	<let name="global-ten-ids-duplicates" value="for $val in distinct-values($global-ten-ids) return $val[count($global-ten-ids[. = $val]) > 1]"/>
+	<let name="global-ten-ids-duplicates" value="for $val in distinct-values(/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID) return $val[count(/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID[. = $val]) > 1]"/>
 	<let name="global-tpa-ids-duplicates" value="for $val in distinct-values($global-tpa-ids) return $val[count($global-tpa-ids[. = $val]) > 1]"/>
 	
 	<!-- Rules on identifiers -->

--- a/schematrons/dynamic/validation-stage-5m.sch
+++ b/schematrons/dynamic/validation-stage-5m.sch
@@ -28,7 +28,7 @@
 	<let name="global-res-ids-duplicates" value="for $val in distinct-values($global-res-ids) return $val[count($global-res-ids[. = $val]) > 1]"/>
 	<let name="global-con-ids-duplicates" value="for $val in distinct-values($global-con-ids) return $val[count($global-con-ids[. = $val]) > 1]"/>
 	<let name="global-con-business-ids-duplicates" value="for $val in distinct-values($global-con-business-ids) return $val[count($global-con-business-ids[. = $val]) > 1]"/>
-	<let name="global-ten-ids-duplicates" value="for $val in distinct-values(/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID) return $val[count(/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID[. = $val]) > 1]"/>
+	<let name="global-ten-ids-duplicates" value="for $val in distinct-values($global-ten-ids) return $val[count($global-ten-ids[. = $val]) > 1]"/>
 	<let name="global-tpa-ids-duplicates" value="for $val in distinct-values($global-tpa-ids) return $val[count($global-tpa-ids[. = $val]) > 1]"/>
 	
 	<!-- Rules on identifiers -->
@@ -75,7 +75,7 @@
 		<assert id="BR-OPT-00301-1410" role="ERROR" diagnostics="ND-LotResult_OPT-301-LotResult-Financing" test="(every $financing in cac:FinancingParty/cac:PartyIdentification/cbc:ID/normalize-space(text()) satisfies ($financing = $global-org-ids)) or not(cac:FinancingParty/cac:PartyIdentification/cbc:ID)">rule|text|BR-OPT-00301-1410</assert>
 		<assert id="BR-OPT-00301-1414" role="ERROR" diagnostics="ND-LotResult_OPT-301-LotResult-Paying" test="(every $payer in cac:PayerParty/cac:PartyIdentification/cbc:ID/normalize-space(text()) satisfies ($payer = $global-org-ids)) or not(cac:PayerParty/cac:PartyIdentification/cbc:ID)">rule|text|BR-OPT-00301-1414</assert>
 		<assert id="BR-OPT-00315-0100" role="ERROR" diagnostics="ND-LotResult_OPT-315-LotResult" test="(every $contract in efac:SettledContract/cbc:ID/normalize-space(text()) satisfies ($contract = $global-con-ids)) or not(efac:SettledContract/cbc:ID)">rule|text|BR-OPT-00315-0100</assert>
-		<assert id="BR-OPT-00320-0100" role="ERROR" diagnostics="ND-LotResult_OPT-320-LotResult" test="(every $tender in efac:LotTender/cbc:ID/normalize-space(text()) satisfies ($tender = /*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID)) or not(efac:LotTender/cbc:ID)">rule|text|BR-OPT-00320-0100</assert>
+		<assert id="BR-OPT-00320-0100" role="ERROR" diagnostics="ND-LotResult_OPT-320-LotResult" test="(every $tender in efac:LotTender/cbc:ID/normalize-space(text()) satisfies ($tender = $global-ten-ids)) or not(efac:LotTender/cbc:ID)">rule|text|BR-OPT-00320-0100</assert>
 	</rule>
 
 	<rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract">
@@ -83,4 +83,11 @@
 		<assert id="BR-OPT-00300-0252" role="ERROR" diagnostics="ND-SettledContract_OPT-300-Contract-Signatory" test="(every $signatory in cac:SignatoryParty/cac:PartyIdentification/cbc:ID/normalize-space(text()) satisfies ($signatory = $global-org-ids)) or not(cac:SignatoryParty/cac:PartyIdentification/cbc:ID)">rule|text|BR-OPT-00300-0252</assert>
 	</rule>
 
+	<rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID">
+		<assert id="BR-OPT-00321-0100-slow" role="ERROR" test="count(for $x in ., $y in /*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID[. = $x] return $y) = 1">rule|text|BR-OPT-00321-0100</assert>
+	</rule>
+
+	<rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:ContractReference/cbc:ID">
+		<assert id="BR-BT-00150-0101-slow" role="ERROR" test="count(for $x in ., $y in /*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:ContractReference/cbc:ID[. = $x] return $y) = 1">rule|text|BR-BT-00150-0101</assert>
+	</rule>
 </pattern>

--- a/schematrons/dynamic/validation-stage-5m.sch
+++ b/schematrons/dynamic/validation-stage-5m.sch
@@ -83,6 +83,14 @@
 		<assert id="BR-OPT-00300-0252" role="ERROR" diagnostics="ND-SettledContract_OPT-300-Contract-Signatory" test="(every $signatory in cac:SignatoryParty/cac:PartyIdentification/cbc:ID/normalize-space(text()) satisfies ($signatory = $global-org-ids)) or not(cac:SignatoryParty/cac:PartyIdentification/cbc:ID)">rule|text|BR-OPT-00300-0252</assert>
 	</rule>
 
+	<rule context="/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cbc:ID">
+		<assert id="BR-BT-00022-0241-slow" role="ERROR" test="count(for $x in ., $y in /*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cbc:ID[. = $x] return $y) = 1">rule|text|BR-BT-00022-0241</assert>
+	</rule>
+
+	<rule context="/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cbc:ID">
+		<assert id="BR-BT-00137-0201-slow" role="ERROR" test="count(for $x in ., $y in /*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cbc:ID[. = $x] return $y) = 1">rule|text|BR-BT-00137-0201</assert>
+	</rule>
+		
 	<rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID">
 		<assert id="BR-OPT-00321-0100-slow" role="ERROR" test="count(for $x in ., $y in /*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID[. = $x] return $y) = 1">rule|text|BR-OPT-00321-0100</assert>
 	</rule>
@@ -90,4 +98,9 @@
 	<rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:ContractReference/cbc:ID">
 		<assert id="BR-BT-00150-0101-slow" role="ERROR" test="count(for $x in ., $y in /*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:ContractReference/cbc:ID[. = $x] return $y) = 1">rule|text|BR-BT-00150-0101</assert>
 	</rule>
+
+	<rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/cbc:ID">
+		<assert id="BR-OPT-00210-0100-slow" role="ERROR" test="count(for $x in ., $y in /*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/cbc:ID[. = $x] return $y) = 1">rule|text|BR-OPT-00210-0100</assert>
+	</rule>
+
 </pattern>

--- a/schematrons/static/validation-stage-5m.sch
+++ b/schematrons/static/validation-stage-5m.sch
@@ -11,8 +11,7 @@
 	<let name="global-res-ids" value="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/cbc:ID" />
 	<let name="global-con-ids" value="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/cbc:ID"/>
 	<let name="global-con-business-ids" value="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:ContractReference/cbc:ID"/>
-	<let name="global-ten-ids" value="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/
-	efac:LotTender/cbc:ID"/>
+	<let name="global-ten-ids" value="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID"/>
 	<let name="global-tpa-ids" value="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/cbc:ID"/>
 	
 	<!-- Variable for references to identifiers -->
@@ -76,7 +75,7 @@
 		<assert id="BR-OPT-00301-1410" role="ERROR" diagnostics="ND-LotResult_OPT-301-LotResult-Financing" test="(every $financing in cac:FinancingParty/cac:PartyIdentification/cbc:ID/normalize-space(text()) satisfies ($financing = $global-org-ids)) or not(cac:FinancingParty/cac:PartyIdentification/cbc:ID)">rule|text|BR-OPT-00301-1410</assert>
 		<assert id="BR-OPT-00301-1414" role="ERROR" diagnostics="ND-LotResult_OPT-301-LotResult-Paying" test="(every $payer in cac:PayerParty/cac:PartyIdentification/cbc:ID/normalize-space(text()) satisfies ($payer = $global-org-ids)) or not(cac:PayerParty/cac:PartyIdentification/cbc:ID)">rule|text|BR-OPT-00301-1414</assert>
 		<assert id="BR-OPT-00315-0100" role="ERROR" diagnostics="ND-LotResult_OPT-315-LotResult" test="(every $contract in efac:SettledContract/cbc:ID/normalize-space(text()) satisfies ($contract = $global-con-ids)) or not(efac:SettledContract/cbc:ID)">rule|text|BR-OPT-00315-0100</assert>
-		<assert id="BR-OPT-00320-0100" role="ERROR" diagnostics="ND-LotResult_OPT-320-LotResult" test="(every $tender in efac:LotTender/cbc:ID/normalize-space(text()) satisfies ($tender = $global-ten-ids)) or not(efac:LotTender/cbc:ID)">rule|text|BR-OPT-00320-0100</assert>
+		<assert id="BR-OPT-00320-0100" role="ERROR" diagnostics="ND-LotResult_OPT-320-LotResult" test="(every $tender in efac:LotTender/cbc:ID/normalize-space(text()) satisfies ($tender = /*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID)) or not(efac:LotTender/cbc:ID)">rule|text|BR-OPT-00320-0100</assert>
 	</rule>
 
 	<rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract">

--- a/schematrons/static/validation-stage-5m.sch
+++ b/schematrons/static/validation-stage-5m.sch
@@ -83,23 +83,4 @@
 		<assert id="BR-OPT-00300-0252" role="ERROR" diagnostics="ND-SettledContract_OPT-300-Contract-Signatory" test="(every $signatory in cac:SignatoryParty/cac:PartyIdentification/cbc:ID/normalize-space(text()) satisfies ($signatory = $global-org-ids)) or not(cac:SignatoryParty/cac:PartyIdentification/cbc:ID)">rule|text|BR-OPT-00300-0252</assert>
 	</rule>
 
-	<rule context="/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cbc:ID">
-		<assert id="BR-BT-00022-0241-slow" role="ERROR" test="count(for $x in ., $y in /*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cbc:ID[. = $x] return $y) = 1">rule|text|BR-BT-00022-0241</assert>
-	</rule>
-
-	<rule context="/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cbc:ID">
-		<assert id="BR-BT-00137-0201-slow" role="ERROR" test="count(for $x in ., $y in /*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cbc:ID[. = $x] return $y) = 1">rule|text|BR-BT-00137-0201</assert>
-	</rule>
-		
-	<rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID">
-		<assert id="BR-OPT-00321-0100-slow" role="ERROR" test="count(for $x in ., $y in /*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID[. = $x] return $y) = 1">rule|text|BR-OPT-00321-0100</assert>
-	</rule>
-
-	<rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:ContractReference/cbc:ID">
-		<assert id="BR-BT-00150-0101-slow" role="ERROR" test="count(for $x in ., $y in /*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:ContractReference/cbc:ID[. = $x] return $y) = 1">rule|text|BR-BT-00150-0101</assert>
-	</rule>
-
-	<rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/cbc:ID">
-		<assert id="BR-OPT-00210-0100-slow" role="ERROR" test="count(for $x in ., $y in /*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/cbc:ID[. = $x] return $y) = 1">rule|text|BR-OPT-00210-0100</assert>
-	</rule>
 </pattern>

--- a/schematrons/static/validation-stage-5m.sch
+++ b/schematrons/static/validation-stage-5m.sch
@@ -83,11 +83,23 @@
 		<assert id="BR-OPT-00300-0252" role="ERROR" diagnostics="ND-SettledContract_OPT-300-Contract-Signatory" test="(every $signatory in cac:SignatoryParty/cac:PartyIdentification/cbc:ID/normalize-space(text()) satisfies ($signatory = $global-org-ids)) or not(cac:SignatoryParty/cac:PartyIdentification/cbc:ID)">rule|text|BR-OPT-00300-0252</assert>
 	</rule>
 
+	<rule context="/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cbc:ID">
+		<assert id="BR-BT-00022-0241-slow" role="ERROR" test="count(for $x in ., $y in /*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cbc:ID[. = $x] return $y) = 1">rule|text|BR-BT-00022-0241</assert>
+	</rule>
+
+	<rule context="/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cbc:ID">
+		<assert id="BR-BT-00137-0201-slow" role="ERROR" test="count(for $x in ., $y in /*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cbc:ID[. = $x] return $y) = 1">rule|text|BR-BT-00137-0201</assert>
+	</rule>
+		
 	<rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID">
 		<assert id="BR-OPT-00321-0100-slow" role="ERROR" test="count(for $x in ., $y in /*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID[. = $x] return $y) = 1">rule|text|BR-OPT-00321-0100</assert>
 	</rule>
 
 	<rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:ContractReference/cbc:ID">
 		<assert id="BR-BT-00150-0101-slow" role="ERROR" test="count(for $x in ., $y in /*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:ContractReference/cbc:ID[. = $x] return $y) = 1">rule|text|BR-BT-00150-0101</assert>
+	</rule>
+
+	<rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/cbc:ID">
+		<assert id="BR-OPT-00210-0100-slow" role="ERROR" test="count(for $x in ., $y in /*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/cbc:ID[. = $x] return $y) = 1">rule|text|BR-OPT-00210-0100</assert>
 	</rule>
 </pattern>

--- a/schematrons/static/validation-stage-5m.sch
+++ b/schematrons/static/validation-stage-5m.sch
@@ -28,7 +28,7 @@
 	<let name="global-res-ids-duplicates" value="for $val in distinct-values($global-res-ids) return $val[count($global-res-ids[. = $val]) > 1]"/>
 	<let name="global-con-ids-duplicates" value="for $val in distinct-values($global-con-ids) return $val[count($global-con-ids[. = $val]) > 1]"/>
 	<let name="global-con-business-ids-duplicates" value="for $val in distinct-values($global-con-business-ids) return $val[count($global-con-business-ids[. = $val]) > 1]"/>
-	<let name="global-ten-ids-duplicates" value="for $val in distinct-values($global-ten-ids) return $val[count($global-ten-ids[. = $val]) > 1]"/>
+	<let name="global-ten-ids-duplicates" value="for $val in distinct-values(/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID) return $val[count(/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID[. = $val]) > 1]"/>
 	<let name="global-tpa-ids-duplicates" value="for $val in distinct-values($global-tpa-ids) return $val[count($global-tpa-ids[. = $val]) > 1]"/>
 	
 	<!-- Rules on identifiers -->

--- a/schematrons/static/validation-stage-5m.sch
+++ b/schematrons/static/validation-stage-5m.sch
@@ -28,7 +28,7 @@
 	<let name="global-res-ids-duplicates" value="for $val in distinct-values($global-res-ids) return $val[count($global-res-ids[. = $val]) > 1]"/>
 	<let name="global-con-ids-duplicates" value="for $val in distinct-values($global-con-ids) return $val[count($global-con-ids[. = $val]) > 1]"/>
 	<let name="global-con-business-ids-duplicates" value="for $val in distinct-values($global-con-business-ids) return $val[count($global-con-business-ids[. = $val]) > 1]"/>
-	<let name="global-ten-ids-duplicates" value="for $val in distinct-values(/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID) return $val[count(/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID[. = $val]) > 1]"/>
+	<let name="global-ten-ids-duplicates" value="for $val in distinct-values($global-ten-ids) return $val[count($global-ten-ids[. = $val]) > 1]"/>
 	<let name="global-tpa-ids-duplicates" value="for $val in distinct-values($global-tpa-ids) return $val[count($global-tpa-ids[. = $val]) > 1]"/>
 	
 	<!-- Rules on identifiers -->
@@ -75,7 +75,7 @@
 		<assert id="BR-OPT-00301-1410" role="ERROR" diagnostics="ND-LotResult_OPT-301-LotResult-Financing" test="(every $financing in cac:FinancingParty/cac:PartyIdentification/cbc:ID/normalize-space(text()) satisfies ($financing = $global-org-ids)) or not(cac:FinancingParty/cac:PartyIdentification/cbc:ID)">rule|text|BR-OPT-00301-1410</assert>
 		<assert id="BR-OPT-00301-1414" role="ERROR" diagnostics="ND-LotResult_OPT-301-LotResult-Paying" test="(every $payer in cac:PayerParty/cac:PartyIdentification/cbc:ID/normalize-space(text()) satisfies ($payer = $global-org-ids)) or not(cac:PayerParty/cac:PartyIdentification/cbc:ID)">rule|text|BR-OPT-00301-1414</assert>
 		<assert id="BR-OPT-00315-0100" role="ERROR" diagnostics="ND-LotResult_OPT-315-LotResult" test="(every $contract in efac:SettledContract/cbc:ID/normalize-space(text()) satisfies ($contract = $global-con-ids)) or not(efac:SettledContract/cbc:ID)">rule|text|BR-OPT-00315-0100</assert>
-		<assert id="BR-OPT-00320-0100" role="ERROR" diagnostics="ND-LotResult_OPT-320-LotResult" test="(every $tender in efac:LotTender/cbc:ID/normalize-space(text()) satisfies ($tender = /*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID)) or not(efac:LotTender/cbc:ID)">rule|text|BR-OPT-00320-0100</assert>
+		<assert id="BR-OPT-00320-0100" role="ERROR" diagnostics="ND-LotResult_OPT-320-LotResult" test="(every $tender in efac:LotTender/cbc:ID/normalize-space(text()) satisfies ($tender = $global-ten-ids)) or not(efac:LotTender/cbc:ID)">rule|text|BR-OPT-00320-0100</assert>
 	</rule>
 
 	<rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract">
@@ -83,4 +83,11 @@
 		<assert id="BR-OPT-00300-0252" role="ERROR" diagnostics="ND-SettledContract_OPT-300-Contract-Signatory" test="(every $signatory in cac:SignatoryParty/cac:PartyIdentification/cbc:ID/normalize-space(text()) satisfies ($signatory = $global-org-ids)) or not(cac:SignatoryParty/cac:PartyIdentification/cbc:ID)">rule|text|BR-OPT-00300-0252</assert>
 	</rule>
 
+	<rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID">
+		<assert id="BR-OPT-00321-0100-slow" role="ERROR" test="count(for $x in ., $y in /*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/cbc:ID[. = $x] return $y) = 1">rule|text|BR-OPT-00321-0100</assert>
+	</rule>
+
+	<rule context="/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:ContractReference/cbc:ID">
+		<assert id="BR-BT-00150-0101-slow" role="ERROR" test="count(for $x in ., $y in /*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:ContractReference/cbc:ID[. = $x] return $y) = 1">rule|text|BR-BT-00150-0101</assert>
+	</rule>
 </pattern>


### PR DESCRIPTION
Add a new workflow that runs the benchmark in the SDK Analyzer.
This workflow will fail if the results show that the rules are slower that expected, and it will add a comment on the commit that triggered it.
See for example: https://github.com/OP-TED/eForms-SDK/commit/06d428a2110cb4886e90e0e8f9b0f0dd36ea9a7c

Several commits here were for testing, and various attempts to make it work, and they were reverted, so better to look at the overall diff.