### PR TITLE
efx-grammar: Remove unneeded alternative in a parser rule (TEDEFO-3718)

### DIFF
--- a/efx-grammar/Efx.g4
+++ b/efx-grammar/Efx.g4
@@ -350,7 +350,7 @@ contextVariableSpecifier: variable=variableReference ColonColon;
  * It looks more "complicated" but it is necessary for parsing (see fieldReferenceWithFieldContextOverride). 
  */
 attributeReference:fieldReference SlashAt Identifier;
-fieldReference: fieldReferenceWithFieldContextOverride | fieldReferenceInOtherNotice | absoluteFieldReference;
+fieldReference: fieldReferenceInOtherNotice | absoluteFieldReference;
 fieldReferenceInOtherNotice: (noticeReference Slash)? reference=fieldReferenceWithVariableContextOverride;
 fieldReferenceWithVariableContextOverride: contextVariableSpecifier? reference=fieldReferenceWithNodeContextOverride;
 fieldReferenceWithNodeContextOverride: contextNodeSpecifier? reference=fieldReferenceWithFieldContextOverride;


### PR DESCRIPTION
In the fieldReference parser rule, having a direct reference to fieldReferenceWithFieldContextOverride is not needed, because fieldReferenceInOtherNotice can also match it with a chain of rules.

So removing this unneeded reference removes the ambiguity in the rule, which reduces the parsing time, as the parser does not spend time looking ahead and then backtracking.

This does not change the result of the translation.