### PR TITLE
workflows: Schedule benchmark to run every few days

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,7 +1,15 @@
 name: Benchmark Schematron rules with the SDK Analyzer
 
-# Allows to also run this workflow manually from the Actions tab
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  # Allows to also run this workflow manually from the Actions tab
+  workflow_dispatch:
+  # Run this workflow every Tuesday and Friday at 05:00
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 5 * * 2,5'
+
 
 jobs:
   benchmark:


### PR DESCRIPTION
The previous benchmark results are stored in the GitHub Cache, but cache entries are deleted if they are not accessed in over 7 days. And if the cache is empty, we will not detect that the rules are slower.

So schedule the benchmark to run automatically every Tuesday and Friday at 05:00 in the morning, to avoid this deletion.  It might also be helpful as a double-check.
The scheduled run will be on the develop branch.