### PR TITLE
Prepare SDK 1.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# SDK 1.9.5 Release Notes
+
+This release brings the following corrections in the notice visualisation templates:
+
+* Add back the display of BT-748-Lot for all relevant notice subtypes. It was incorrectly removed in the previous version.
+
+A comprehensive list of changes between SDK 1.9.4 and SDK 1.9.5 can be seen at <https://github.com/OP-TED/eForms-SDK/compare/1.9.4...1.9.5>
+
+You can explore the changes between those versions at <https://docs.ted.europa.eu/eforms-sdk-explorer?base=1.9.4&version=1.9.5>
+
 # SDK 1.9.4 Release Notes
 
 This release brings the following corrections in the validation rules, making them more permissive:

--- a/fields/fields.json
+++ b/fields/fields.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "eforms-sdk-1.9.4",
+  "sdkVersion" : "eforms-sdk-1.9.5",
   "metadataDatabase" : {
     "version" : "1.9.5",
     "createdOn" : "2023-10-05T15:56:54"

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>eu.europa.ted.eforms</groupId>
   <artifactId>eforms-sdk</artifactId>
-  <version>1.9.4</version>
+  <version>1.9.5</version>
   <packaging>jar</packaging>
 
   <name>eForms SDK</name>
@@ -48,7 +48,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.build.outputTimestamp>2024-08-13T06:45:45Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2025-01-20T14:04:09Z</project.build.outputTimestamp>
 
     <sonatype.server.url>s01.oss.sonatype.org</sonatype.server.url>
 

--- a/view-templates/10.efx
+++ b/view-templates/10.efx
@@ -134,6 +134,7 @@
 				{BT-747-Lot} #{field|name|BT-747-Lot}: #{BT-747-Lot} // Selection Criterion Type
 				{ND-SelectionCriteria[BT-749-Lot is present]} #{field|name|BT-749-Lot}: ${BT-749-Lot} // Selection Criterion Name
 				{ND-SelectionCriteria[BT-750-Lot is present]} #{field|name|BT-750-Lot}: ${BT-750-Lot} // Selection Criterion Description
+				{BT-748-Lot} #{field|name|BT-748-Lot}: #{BT-748-Lot} // Use of this criterion
 				{BT-40-Lot[BT-40-Lot == TRUE]} #{field|name|BT-40-Lot} // Selection Criteria Second Stage Invite
 				{BT-7531-Lot} #{BT-7531-Lot}: ${format-number(BT-752-Lot-WeightNumber, '###,##0.###,###,###')} // Number Weight
 				{BT-7532-Lot} #{BT-7532-Lot}: ${format-number(BT-752-Lot-ThresholdNumber, '###,##0.###,###,###')} // Number Threshold

--- a/view-templates/11.efx
+++ b/view-templates/11.efx
@@ -135,6 +135,7 @@
 				{BT-747-Lot} #{field|name|BT-747-Lot}: #{BT-747-Lot} // Selection Criterion Type
 				{ND-SelectionCriteria[BT-749-Lot is present]} #{field|name|BT-749-Lot}: ${BT-749-Lot} // Selection Criterion Name
 				{ND-SelectionCriteria[BT-750-Lot is present]} #{field|name|BT-750-Lot}: ${BT-750-Lot} // Selection Criterion Description
+				{BT-748-Lot} #{field|name|BT-748-Lot}: #{BT-748-Lot} // Use of this criterion
 				{BT-40-Lot[BT-40-Lot == TRUE]} #{field|name|BT-40-Lot} // Selection Criteria Second Stage Invite
 				{BT-7531-Lot} #{BT-7531-Lot}: ${format-number(BT-752-Lot-WeightNumber, '###,##0.###,###,###')} // Number Weight
 				{BT-7532-Lot} #{BT-7532-Lot}: ${format-number(BT-752-Lot-ThresholdNumber, '###,##0.###,###,###')} // Number Threshold

--- a/view-templates/12.efx
+++ b/view-templates/12.efx
@@ -133,6 +133,7 @@
 				{BT-747-Lot} #{field|name|BT-747-Lot}: #{BT-747-Lot} // Selection Criterion Type
 				{ND-SelectionCriteria[BT-749-Lot is present]} #{field|name|BT-749-Lot}: ${BT-749-Lot} // Selection Criterion Name
 				{ND-SelectionCriteria[BT-750-Lot is present]} #{field|name|BT-750-Lot}: ${BT-750-Lot} // Selection Criterion Description
+				{BT-748-Lot} #{field|name|BT-748-Lot}: #{BT-748-Lot} // Use of this criterion
 				{BT-40-Lot[BT-40-Lot == TRUE]} #{field|name|BT-40-Lot} // Selection Criteria Second Stage Invite
 				{BT-7531-Lot} #{BT-7531-Lot}: ${format-number(BT-752-Lot-WeightNumber, '###,##0.###,###,###')} // Number Weight
 				{BT-7532-Lot} #{BT-7532-Lot}: ${format-number(BT-752-Lot-ThresholdNumber, '###,##0.###,###,###')} // Number Threshold

--- a/view-templates/13.efx
+++ b/view-templates/13.efx
@@ -134,6 +134,7 @@
 				{BT-747-Lot} #{field|name|BT-747-Lot}: #{BT-747-Lot} // Selection Criterion Type
 				{ND-SelectionCriteria[BT-749-Lot is present]} #{field|name|BT-749-Lot}: ${BT-749-Lot} // Selection Criterion Name
 				{ND-SelectionCriteria[BT-750-Lot is present]} #{field|name|BT-750-Lot}: ${BT-750-Lot} // Selection Criterion Description
+				{BT-748-Lot} #{field|name|BT-748-Lot}: #{BT-748-Lot} // Use of this criterion
 				{BT-40-Lot[BT-40-Lot == TRUE]} #{field|name|BT-40-Lot} // Selection Criteria Second Stage Invite
 				{BT-7531-Lot} #{BT-7531-Lot}: ${format-number(BT-752-Lot-WeightNumber, '###,##0.###,###,###')} // Number Weight
 				{BT-7532-Lot} #{BT-7532-Lot}: ${format-number(BT-752-Lot-ThresholdNumber, '###,##0.###,###,###')} // Number Threshold

--- a/view-templates/14.efx
+++ b/view-templates/14.efx
@@ -126,6 +126,7 @@
 				{BT-747-Lot} #{field|name|BT-747-Lot}: #{BT-747-Lot} // Selection Criterion Type
 				{ND-SelectionCriteria[BT-749-Lot is present]} #{field|name|BT-749-Lot}: ${BT-749-Lot} // Selection Criterion Name
 				{ND-SelectionCriteria[BT-750-Lot is present]} #{field|name|BT-750-Lot}: ${BT-750-Lot} // Selection Criterion Description
+				{BT-748-Lot} #{field|name|BT-748-Lot}: #{BT-748-Lot} // Use of this criterion
 			0 {ND-LotTenderingTerms[(BT-50-Lot is present) or (BT-51-Lot is present) or (BT-52-Lot == TRUE) or (BT-120-Lot == TRUE)]} #{auxiliary|text|second-stage}: // Information about the second stage of a two-stage procedure
 				{BT-50-Lot[BT-50-Lot is present]} #{field|name|BT-50-Lot}: ${BT-50-Lot} // Minimum Candidates
 				{BT-51-Lot[BT-51-Lot is present]} #{field|name|BT-51-Lot}: ${BT-51-Lot} // Maximum Candidates

--- a/view-templates/15.efx
+++ b/view-templates/15.efx
@@ -97,6 +97,7 @@
 				{BT-747-Lot} #{field|name|BT-747-Lot}: #{BT-747-Lot} // Selection Criterion Type
 				{ND-SelectionCriteria[BT-749-Lot is present]} #{field|name|BT-749-Lot}: ${BT-749-Lot} // Selection Criterion Name
 				{ND-SelectionCriteria[BT-750-Lot is present]} #{field|name|BT-750-Lot}: ${BT-750-Lot} // Selection Criterion Description
+				{BT-748-Lot} #{field|name|BT-748-Lot}: #{BT-748-Lot} // Use of this criterion
 				{BT-40-Lot[BT-40-Lot == TRUE]} #{field|name|BT-40-Lot} // Selection Criteria Second Stage Invite
 				{BT-7531-Lot} #{BT-7531-Lot}: ${format-number(BT-752-Lot-WeightNumber, '###,##0.###,###,###')} // Number Weight
 				{BT-7532-Lot} #{BT-7532-Lot}: ${format-number(BT-752-Lot-ThresholdNumber, '###,##0.###,###,###')} // Number Threshold

--- a/view-templates/16.efx
+++ b/view-templates/16.efx
@@ -138,6 +138,7 @@
 				{BT-747-Lot} #{field|name|BT-747-Lot}: #{BT-747-Lot} // Selection Criterion Type
 				{ND-SelectionCriteria[BT-749-Lot is present]} #{field|name|BT-749-Lot}: ${BT-749-Lot} // Selection Criterion Name
 				{ND-SelectionCriteria[BT-750-Lot is present]} #{field|name|BT-750-Lot}: ${BT-750-Lot} // Selection Criterion Description
+				{BT-748-Lot} #{field|name|BT-748-Lot}: #{BT-748-Lot} // Use of this criterion
 				{BT-40-Lot[BT-40-Lot == TRUE]} #{field|name|BT-40-Lot} // Selection Criteria Second Stage Invite
 				{BT-7531-Lot} #{BT-7531-Lot}: ${format-number(BT-752-Lot-WeightNumber, '###,##0.###,###,###')} // Number Weight
 				{BT-7532-Lot} #{BT-7532-Lot}: ${format-number(BT-752-Lot-ThresholdNumber, '###,##0.###,###,###')} // Number Threshold

--- a/view-templates/17.efx
+++ b/view-templates/17.efx
@@ -139,6 +139,7 @@
 				{BT-747-Lot} #{field|name|BT-747-Lot}: #{BT-747-Lot} // Selection Criterion Type
 				{ND-SelectionCriteria[BT-749-Lot is present]} #{field|name|BT-749-Lot}: ${BT-749-Lot} // Selection Criterion Name
 				{ND-SelectionCriteria[BT-750-Lot is present]} #{field|name|BT-750-Lot}: ${BT-750-Lot} // Selection Criterion Description
+				{BT-748-Lot} #{field|name|BT-748-Lot}: #{BT-748-Lot} // Use of this criterion
 				{BT-40-Lot[BT-40-Lot == TRUE]} #{field|name|BT-40-Lot} // Selection Criteria Second Stage Invite
 				{BT-7531-Lot} #{BT-7531-Lot}: ${format-number(BT-752-Lot-WeightNumber, '###,##0.###,###,###')} // Number Weight
 				{BT-7532-Lot} #{BT-7532-Lot}: ${format-number(BT-752-Lot-ThresholdNumber, '###,##0.###,###,###')} // Number Threshold

--- a/view-templates/18.efx
+++ b/view-templates/18.efx
@@ -139,6 +139,7 @@
 				{BT-747-Lot} #{field|name|BT-747-Lot}: #{BT-747-Lot} // Selection Criterion Type
 				{ND-SelectionCriteria[BT-749-Lot is present]} #{field|name|BT-749-Lot}: ${BT-749-Lot} // Selection Criterion Name
 				{ND-SelectionCriteria[BT-750-Lot is present]} #{field|name|BT-750-Lot}: ${BT-750-Lot} // Selection Criterion Description
+				{BT-748-Lot} #{field|name|BT-748-Lot}: #{BT-748-Lot} // Use of this criterion
 				{BT-40-Lot[BT-40-Lot == TRUE]} #{field|name|BT-40-Lot} // Selection Criteria Second Stage Invite
 				{BT-7531-Lot} #{BT-7531-Lot}: ${format-number(BT-752-Lot-WeightNumber, '###,##0.###,###,###')} // Number Weight
 				{BT-7532-Lot} #{BT-7532-Lot}: ${format-number(BT-752-Lot-ThresholdNumber, '###,##0.###,###,###')} // Number Threshold

--- a/view-templates/19.efx
+++ b/view-templates/19.efx
@@ -133,6 +133,7 @@
 				{BT-747-Lot} #{field|name|BT-747-Lot}: #{BT-747-Lot} // Selection Criterion Type
 				{ND-SelectionCriteria[BT-749-Lot is present]} #{field|name|BT-749-Lot}: ${BT-749-Lot} // Selection Criterion Name
 				{ND-SelectionCriteria[BT-750-Lot is present]} #{field|name|BT-750-Lot}: ${BT-750-Lot} // Selection Criterion Description
+				{BT-748-Lot} #{field|name|BT-748-Lot}: #{BT-748-Lot} // Use of this criterion
 		10 {ND-LotAwardCriteria} #{auxiliary|text|award-criteria} // 5.1.10 Award criteria
 			0 {ND-LotAwardCriterion} #{auxiliary|text|criterion}: // Award Criterion
 				0 {ND-LotAwardCriterion[BT-539-Lot != 'unpublished']} #{field|name|BT-539-Lot}: #{BT-539-Lot} // Type

--- a/view-templates/20.efx
+++ b/view-templates/20.efx
@@ -135,6 +135,7 @@
 				{BT-747-Lot} #{field|name|BT-747-Lot}: #{BT-747-Lot} // Selection Criterion Type
 				{ND-SelectionCriteria[BT-749-Lot is present]} #{field|name|BT-749-Lot}: ${BT-749-Lot} // Selection Criterion Name
 				{ND-SelectionCriteria[BT-750-Lot is present]} #{field|name|BT-750-Lot}: ${BT-750-Lot} // Selection Criterion Description
+				{BT-748-Lot} #{field|name|BT-748-Lot}: #{BT-748-Lot} // Use of this criterion
 				{BT-40-Lot[BT-40-Lot == TRUE]} #{field|name|BT-40-Lot} // Selection Criteria Second Stage Invite
 				{BT-7531-Lot} #{BT-7531-Lot}: ${format-number(BT-752-Lot-WeightNumber, '###,##0.###,###,###')} // Number Weight
 				{BT-7532-Lot} #{BT-7532-Lot}: ${format-number(BT-752-Lot-ThresholdNumber, '###,##0.###,###,###')} // Number Threshold

--- a/view-templates/21.efx
+++ b/view-templates/21.efx
@@ -136,6 +136,7 @@
 				{BT-747-Lot} #{field|name|BT-747-Lot}: #{BT-747-Lot} // Selection Criterion Type
 				{ND-SelectionCriteria[BT-749-Lot is present]} #{field|name|BT-749-Lot}: ${BT-749-Lot} // Selection Criterion Name
 				{ND-SelectionCriteria[BT-750-Lot is present]} #{field|name|BT-750-Lot}: ${BT-750-Lot} // Selection Criterion Description
+				{BT-748-Lot} #{field|name|BT-748-Lot}: #{BT-748-Lot} // Use of this criterion
 				{BT-40-Lot[BT-40-Lot == TRUE]} #{field|name|BT-40-Lot} // Selection Criteria Second Stage Invite
 				{BT-7531-Lot} #{BT-7531-Lot}: ${format-number(BT-752-Lot-WeightNumber, '###,##0.###,###,###')} // Number Weight
 				{BT-7532-Lot} #{BT-7532-Lot}: ${format-number(BT-752-Lot-ThresholdNumber, '###,##0.###,###,###')} // Number Threshold

--- a/view-templates/22.efx
+++ b/view-templates/22.efx
@@ -133,6 +133,7 @@
 				{BT-747-Lot} #{field|name|BT-747-Lot}: #{BT-747-Lot} // Selection Criterion Type
 				{ND-SelectionCriteria[BT-749-Lot is present]} #{field|name|BT-749-Lot}: ${BT-749-Lot} // Selection Criterion Name
 				{ND-SelectionCriteria[BT-750-Lot is present]} #{field|name|BT-750-Lot}: ${BT-750-Lot} // Selection Criterion Description
+				{BT-748-Lot} #{field|name|BT-748-Lot}: #{BT-748-Lot} // Use of this criterion
 				{BT-40-Lot[BT-40-Lot == TRUE]} #{field|name|BT-40-Lot} // Selection Criteria Second Stage Invite
 				{BT-7531-Lot} #{BT-7531-Lot}: ${format-number(BT-752-Lot-WeightNumber, '###,##0.###,###,###')} // Number Weight
 				{BT-7532-Lot} #{BT-7532-Lot}: ${format-number(BT-752-Lot-ThresholdNumber, '###,##0.###,###,###')} // Number Threshold

--- a/view-templates/23.efx
+++ b/view-templates/23.efx
@@ -108,6 +108,7 @@
 				{BT-747-Lot} #{field|name|BT-747-Lot}: #{BT-747-Lot} // Selection Criterion Type
 				{ND-SelectionCriteria[BT-749-Lot is present]} #{field|name|BT-749-Lot}: ${BT-749-Lot} // Selection Criterion Name
 				{ND-SelectionCriteria[BT-750-Lot is present]} #{field|name|BT-750-Lot}: ${BT-750-Lot} // Selection Criterion Description
+				{BT-748-Lot} #{field|name|BT-748-Lot}: #{BT-748-Lot} // Use of this criterion
 				{BT-40-Lot[BT-40-Lot == TRUE]} #{field|name|BT-40-Lot} // Selection Criteria Second Stage Invite
 				{BT-7531-Lot} #{BT-7531-Lot}: ${format-number(BT-752-Lot-WeightNumber, '###,##0.###,###,###')} // Number Weight
 				{BT-7532-Lot} #{BT-7532-Lot}: ${format-number(BT-752-Lot-ThresholdNumber, '###,##0.###,###,###')} // Number Threshold

--- a/view-templates/24.efx
+++ b/view-templates/24.efx
@@ -109,6 +109,7 @@
 				{BT-747-Lot} #{field|name|BT-747-Lot}: #{BT-747-Lot} // Selection Criterion Type
 				{ND-SelectionCriteria[BT-749-Lot is present]} #{field|name|BT-749-Lot}: ${BT-749-Lot} // Selection Criterion Name
 				{ND-SelectionCriteria[BT-750-Lot is present]} #{field|name|BT-750-Lot}: ${BT-750-Lot} // Selection Criterion Description
+				{BT-748-Lot} #{field|name|BT-748-Lot}: #{BT-748-Lot} // Use of this criterion
 				{BT-40-Lot[BT-40-Lot == TRUE]} #{field|name|BT-40-Lot} // Selection Criteria Second Stage Invite
 				{BT-7531-Lot} #{BT-7531-Lot}: ${format-number(BT-752-Lot-WeightNumber, '###,##0.###,###,###')} // Number Weight
 				{BT-7532-Lot} #{BT-7532-Lot}: ${format-number(BT-752-Lot-ThresholdNumber, '###,##0.###,###,###')} // Number Threshold

--- a/view-templates/7.efx
+++ b/view-templates/7.efx
@@ -130,6 +130,7 @@
 				{BT-747-Lot} #{field|name|BT-747-Lot}: #{BT-747-Lot} // Selection Criterion Type
 				{ND-SelectionCriteria[BT-749-Lot is present]} #{field|name|BT-749-Lot}: ${BT-749-Lot} // Selection Criterion Name
 				{ND-SelectionCriteria[BT-750-Lot is present]} #{field|name|BT-750-Lot}: ${BT-750-Lot} // Selection Criterion Description
+				{BT-748-Lot} #{field|name|BT-748-Lot}: #{BT-748-Lot} // Use of this criterion
 				{BT-40-Lot[BT-40-Lot == TRUE]} #{field|name|BT-40-Lot} // Selection Criteria Second Stage Invite
 				{BT-7531-Lot} #{BT-7531-Lot}: ${format-number(BT-752-Lot-WeightNumber, '###,##0.###,###,###')} // Number Weight
 				{BT-7532-Lot} #{BT-7532-Lot}: ${format-number(BT-752-Lot-ThresholdNumber, '###,##0.###,###,###')} // Number Threshold

--- a/view-templates/8.efx
+++ b/view-templates/8.efx
@@ -131,6 +131,7 @@
 				{BT-747-Lot} #{field|name|BT-747-Lot}: #{BT-747-Lot} // Selection Criterion Type
 				{ND-SelectionCriteria[BT-749-Lot is present]} #{field|name|BT-749-Lot}: ${BT-749-Lot} // Selection Criterion Name
 				{ND-SelectionCriteria[BT-750-Lot is present]} #{field|name|BT-750-Lot}: ${BT-750-Lot} // Selection Criterion Description
+				{BT-748-Lot} #{field|name|BT-748-Lot}: #{BT-748-Lot} // Use of this criterion
 				{BT-40-Lot[BT-40-Lot == TRUE]} #{field|name|BT-40-Lot} // Selection Criteria Second Stage Invite
 				{BT-7531-Lot} #{BT-7531-Lot}: ${format-number(BT-752-Lot-WeightNumber, '###,##0.###,###,###')} // Number Weight
 				{BT-7532-Lot} #{BT-7532-Lot}: ${format-number(BT-752-Lot-ThresholdNumber, '###,##0.###,###,###')} // Number Threshold

--- a/view-templates/9.efx
+++ b/view-templates/9.efx
@@ -131,6 +131,7 @@
 				{BT-747-Lot} #{field|name|BT-747-Lot}: #{BT-747-Lot} // Selection Criterion Type
 				{ND-SelectionCriteria[BT-749-Lot is present]} #{field|name|BT-749-Lot}: ${BT-749-Lot} // Selection Criterion Name
 				{ND-SelectionCriteria[BT-750-Lot is present]} #{field|name|BT-750-Lot}: ${BT-750-Lot} // Selection Criterion Description
+				{BT-748-Lot} #{field|name|BT-748-Lot}: #{BT-748-Lot} // Use of this criterion
 				{BT-40-Lot[BT-40-Lot == TRUE]} #{field|name|BT-40-Lot} // Selection Criteria Second Stage Invite
 				{BT-7531-Lot} #{BT-7531-Lot}: ${format-number(BT-752-Lot-WeightNumber, '###,##0.###,###,###')} // Number Weight
 				{BT-7532-Lot} #{BT-7532-Lot}: ${format-number(BT-752-Lot-ThresholdNumber, '###,##0.###,###,###')} // Number Threshold

--- a/view-templates/CEI.efx
+++ b/view-templates/CEI.efx
@@ -77,6 +77,7 @@
 				{BT-747-Lot} #{field|name|BT-747-Lot}: #{BT-747-Lot} // Selection Criterion Type
 				{ND-SelectionCriteria[BT-749-Lot is present]} #{field|name|BT-749-Lot}: ${BT-749-Lot} // Selection Criterion Name
 				{ND-SelectionCriteria[BT-750-Lot is present]} #{field|name|BT-750-Lot}: ${BT-750-Lot} // Selection Criterion Description
+				{BT-748-Lot} #{field|name|BT-748-Lot}: #{BT-748-Lot} // Use of this criterion
 		11 {BT-137-Lot[(BT-14-Lot is present) or (BT-632-Lot is present) or (BT-124-Lot is present)]} #{auxiliary|text|procurement-documents} // 5.1.11 Procurement documents
 			{BT-137-Lot[some text:$restricted in (for text:$somerestricted in BT-14-Lot return $somerestricted) satisfies $restricted == 'restricted-document']} #{field|name|BT-14-Lot} // The access to certain procurement documents is restricted. (Lot)
 			{BT-707-Lot} #{field|name|BT-707-Lot}: #{BT-707-Lot} // Justification for restricting access to certain procurement documents (Lot)


### PR DESCRIPTION
This is an exceptional patch release for SDK 1.9.x, to correct a problem in view templates introduced in 1.9.4.

As SDK 1.9 is in its extended lifespan, no other change or correction is applied.