### PR TITLE
Refactor dictionary declaration

### DIFF
--- a/efx-grammar/Efx.g4
+++ b/efx-grammar/Efx.g4
@@ -76,7 +76,9 @@ globalVariableDeclaration
     ;
 
 
-dictionaryDeclaration: Let VariablePrefix dictionaryName=Identifier Index field=fieldContext By (stringExpression | lateBoundScalar) Semicolon;
+dictionaryDeclaration: Let VariablePrefix dictionaryName=Identifier index=dictionaryIndexClause key=dictionaryKeyClause Semicolon;
+dictionaryIndexClause: Index field=fieldContext;
+dictionaryKeyClause: By (stringExpression | lateBoundScalar);
 dictionaryLookup: VariablePrefix dictionaryName=Identifier OpenBracket (stringExpression | lateBoundScalar) CloseBracket;
 
 /* 


### PR DESCRIPTION
....to better separate the key from the context so that a parser can make the former relative to the latter.