### PR TITLE
workflows: Increase alert threshold for benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -45,10 +45,10 @@ jobs:
           output-file-path: jmh-result.json
           external-data-json-path: ./cache/benchmark-data.json
           # Alert if new results are significantly worse than previous results
-          alert-threshold: "110%"
+          alert-threshold: "125%"
           # Mark the workflow as failed if an alert happens
           fail-on-alert: true
-          # Add a comment on the commit that caused the alert
-          comment-on-alert: true
+          # Set to true to add a comment on the commit that caused the alert
+          comment-on-alert: false
           # GitHub API token to make a commit comment
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This will hopefully avoid false alerts when the GitHub runner happens to be a bit slower, while still detecting when schematron rules get slower.

Also change the settings to not add a comment on the commit when there is an alert. Failing the job is enough, and it's easy to find the commit(s) corresponding to the failure.