### PR TITLE
ci: Run the SDK analyser directly instead of via exec-maven-plugin

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,7 +1,12 @@
 name: Build and analyze eForms SDK
 
 on:
+  # Build on pushes to the trunk only (i.e. merges). Source branches are built
+  # via pull_request, so pushing one with an open PR runs the checks just once.
   push:
+    branches:
+      - develop
+      - efx-2
   pull_request:
 
   # Allows to run this workflow manually from the Actions tab

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -21,5 +21,18 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
 
-      - name: Build and analyze SDK
-        run: mvn clean install -Panalyze --no-transfer-progress
+      - name: Build SDK
+        run: mvn clean install --no-transfer-progress
+
+      # Run the analyser as a plain Java process rather than via the
+      # exec-maven-plugin, so its own exit code becomes this step's exit code.
+      # A failing analysis then ends with the analyser's report and a single
+      # "exit code 1", instead of Maven wrapping it in an ExecuteException
+      # stack trace. The classpath (analyser + its dependencies) is still
+      # resolved by Maven from the version pinned in the pom's analyze profile.
+      - name: Analyse SDK
+        run: |
+          mvn --quiet --no-transfer-progress -Panalyze \
+            dependency:build-classpath -Dmdep.outputFile=analyser.classpath -DincludeScope=runtime
+          java -Xmx5g -cp "$(cat analyser.classpath)" \
+            eu.europa.ted.eforms.sdk.analysis.Application "$GITHUB_WORKSPACE"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,7 +1,12 @@
 name: Benchmark Schematron rules with the SDK Analyzer
 
 on:
+  # Build on pushes to the trunk only (i.e. merges). Source branches are built
+  # via pull_request, so pushing one with an open PR runs the checks just once.
   push:
+    branches:
+      - develop
+      - efx-2
   pull_request:
   # Allows to also run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <project.build.outputTimestamp>2026-03-02T11:32:01Z</project.build.outputTimestamp>
 
     <!-- Versions eForms -->
-    <version.eforms-sdk-analyzer>1.14.0</version.eforms-sdk-analyzer>
+    <version.eforms-sdk-analyzer>1.15.0-SNAPSHOT</version.eforms-sdk-analyzer>
 
     <!-- Versions - Plugins -->
     <version.dependency.plugin>3.5.0</version.dependency.plugin>
@@ -131,32 +131,6 @@
           <version>${version.eforms-sdk-analyzer}</version>
         </dependency>
       </dependencies>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>exec-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>validate</phase>
-                <goals>
-                  <goal>exec</goal>
-                </goals>
-                <configuration>
-                  <executable>java</executable>
-                  <arguments>
-                    <argument>-Xmx5g</argument>
-                    <argument>-classpath</argument>
-                    <classpath/>
-                    <argument>eu.europa.ted.eforms.sdk.analysis.Application</argument>
-                    <argument>${project.basedir}</argument>
-                  </arguments>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
     <profile>
       <id>benchmark</id>


### PR DESCRIPTION
## Why

When the analyser finds problems it exits with code 1 (by design). Running it through `exec-maven-plugin` turns that intended exit into an `org.apache.commons.exec.ExecuteException` stack trace through Maven's plugin machinery, printed after the analyser's own report. It reads like a crash and buries the actual findings.

## What

- **`analyze.yml`**: split into *Build SDK* (`mvn clean install`) and *Analyse SDK*. The analyse step resolves the analyser classpath with `dependency:build-classpath` and runs `Application` as a plain Java process, so the analyser's own exit code becomes the step's exit code — a failing analysis ends with the report and a single `exit code 1`, no Maven exception trace.
- **`pom.xml`**: removed the now-unused `exec-maven-plugin` execution from the `analyze` profile (the profile keeps the analyser dependency for classpath resolution). The `benchmark` profile and the plugin declaration are untouched.
- **`pom.xml`**: pinned `version.eforms-sdk-analyzer` to `1.15.0-SNAPSHOT` (was `1.14.0`), so develop runs the analyser that produces the clean deduplicated output, matching develop being SDK `1.15.0-SNAPSHOT`.

## Verification

- `mvn -Panalyze validate` exits 0 (no exec at validate).
- `dependency:build-classpath` resolves `eforms-sdk-analyzer-1.15.0-SNAPSHOT` onto the classpath; `Application` loads and propagates its own exit code.
- Full end-to-end behaviour is exercised by this PR's own analyze run.