### PR TITLE
Bring CI artifact upload to prepare/1.15.0

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -41,3 +41,17 @@ jobs:
             dependency:build-classpath -Dmdep.outputFile=analyser.classpath -DincludeScope=runtime
           java -Xmx5g -cp "$(cat analyser.classpath)" \
             eu.europa.ted.eforms.sdk.analysis.Application "$GITHUB_WORKSPACE"
+
+      # The analyser writes analyzer-summary.txt, analyzer-report.txt and analyzer.log to the working
+      # directory; collect them as artifacts even when the analysis fails (if: always()), so the
+      # details are available without re-running or flooding the job log.
+      - name: Upload analysis artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-analysis
+          path: |
+            analyzer-summary.txt
+            analyzer-report.txt
+            analyzer.log
+          if-no-files-found: warn


### PR DESCRIPTION
Brings the analyse-workflow change (upload `analyzer-report.txt`, `analyzer-summary.txt` and `analyzer.log` as build artifacts) from `develop` to `prepare/1.15.0`. `develop` is ahead of `prepare/1.15.0` by exactly this one change, so this merge is only the workflow update — no other diffs. Once merged, the analyse check on #1375 (`prepare/1.15.0 → release/1.15.0`) runs `prepare/1.15.0`'s workflow and will attach the three artifacts on its next run.