### PR TITLE
Set version to 1.15.1 and pin analyzer to released 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# SDK 1.15.1 Release Notes
+
+This is a patch release of the SDK.
+It does not contain any backwards incompatible changes: software that was able to use version 1.15.0 should also be able to use this version.
+
+### Version correction
+Due to an oversight, several files in the `1.15.0` release still contained the version string `1.15.0-rc.5`. 
+The `sdkVersion` has been corrected from `1.15.0-rc.5` to `1.15.1` in `codelists.json`, `notice-types.json`, `view-templates.json`, all individual notice type definitions, and all codelist files.
+
+### Updates on Fields
+
+* Fixed the casing of `referencedBusinessEntityId` values in `fields.json`:
+  - `"organization"` → `"Organisation"` (in the BUYER instance identifier)
+  - `"contract"` → `"Contract"` (in the contract instance identifier)
+
+<br>
+
 # SDK 1.15.0 Release Notes
 
 This release of the SDK does not contain any backwards incompatible changes: software that was able to use version 1.14.2 should also be able to use this version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ The `sdkVersion` has been corrected from `1.15.0-rc.5` to `1.15.1` in `codelists
 
 ### Updates on Fields
 
-* Fixed the casing of `referencedBusinessEntityId` values in `fields.json`:
-  - `"organization"` → `"Organisation"` (in the BUYER instance identifier)
-  - `"contract"` → `"Contract"` (in the contract instance identifier)
+* Corrected the `referencedBusinessEntityId` values in `fields.json` to reference the business-entity id instead of the identifier-scheme id:
+  - `"organization"` → `"Organisation"` (in the `Buyer` instance identifier)
+  - `"contract"` → `"Contract"` (in the `ContractModification` instance identifier)
 
 <br>
 

--- a/fields/fields.json
+++ b/fields/fields.json
@@ -80,7 +80,7 @@
       "changeIdentifier" : "BUYER"
     },
     "instanceIdentifier" : {
-      "referencedBusinessEntityId" : "organization",
+      "referencedBusinessEntityId" : "Organisation",
       "identifierFieldId" : "OPT-300-Procedure-Buyer",
       "captionFieldId" : "BT-500-Organization-Company"
     }
@@ -231,7 +231,7 @@
       "useInstanceIdentifier" : true
     },
     "instanceIdentifier" : {
-      "referencedBusinessEntityId" : "contract",
+      "referencedBusinessEntityId" : "Contract",
       "identifierFieldId" : "BT-1501(c)-Contract",
       "captionFieldId" : "BT-150-Contract"
     }

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>eu.europa.ted.eforms</groupId>
   <artifactId>eforms-sdk</artifactId>
-  <version>1.15.0</version>
+  <version>1.15.1</version>
   <packaging>jar</packaging>
 
   <name>eForms SDK</name>
@@ -40,7 +40,7 @@
     <project.build.outputTimestamp>2026-07-15T13:00:57Z</project.build.outputTimestamp>
 
     <!-- Versions eForms -->
-    <version.eforms-sdk-analyzer>1.15.0-SNAPSHOT</version.eforms-sdk-analyzer>
+    <version.eforms-sdk-analyzer>1.15.1</version.eforms-sdk-analyzer>
 
     <!-- Versions - Plugins -->
     <version.dependency.plugin>3.5.0</version.dependency.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>eu.europa.ted.eforms</groupId>
   <artifactId>eforms-sdk</artifactId>
-  <version>1.15.0</version>
+  <version>1.15.1</version>
   <packaging>jar</packaging>
 
   <name>eForms SDK</name>
@@ -40,7 +40,7 @@
     <project.build.outputTimestamp>2026-07-15T13:00:57Z</project.build.outputTimestamp>
 
     <!-- Versions eForms -->
-    <version.eforms-sdk-analyzer>1.15.0-SNAPSHOT</version.eforms-sdk-analyzer>
+    <version.eforms-sdk-analyzer>1.15.0</version.eforms-sdk-analyzer>
 
     <!-- Versions - Plugins -->
     <version.dependency.plugin>3.5.0</version.dependency.plugin>


### PR DESCRIPTION
Brings the pom.xml version fixes onto `release/1.15.1`:

- Project version `1.15.0` → `1.15.1` (was lagging behind the re-exported content, which already declares 1.15.1).
- Analyzer dependency `1.15.0-SNAPSHOT` → released `1.15.0` (the analyzer tracks the SDK minor line and is not re-released for patches).

Opening this PR also triggers the `analyze` job (via the pull_request event) so we can see the analyser results on the 1.15.1 content.

Note: the analyser is expected to still report the pre-existing business-entity label findings (PascalCase refs in fields.json vs camelCase keys in the business-entity translations); those are tracked separately and are not addressed here.