### PR TITLE
Back-merge SDK 1.15.1 into develop and bump to 1.16.0-SNAPSHOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# SDK 1.15.1 Release Notes
+
+This is a patch release of the SDK.
+It does not contain any backwards incompatible changes: software that was able to use version 1.15.0 should also be able to use this version.
+
+### Version correction
+Due to an oversight, several files in the `1.15.0` release still contained the version string `1.15.0-rc.5`. 
+The `sdkVersion` has been corrected from `1.15.0-rc.5` to `1.15.1` in `codelists.json`, `notice-types.json`, `view-templates.json`, all individual notice type definitions, and all codelist files.
+
+### Updates on Fields
+
+* Fixed the casing of `referencedBusinessEntityId` values in `fields.json`:
+  - `"organization"` → `"Organisation"` (in the BUYER instance identifier)
+  - `"contract"` → `"Contract"` (in the contract instance identifier)
+
+<br>
+
 # SDK 1.15.0 Release Notes
 
 This release of the SDK does not contain any backwards incompatible changes: software that was able to use version 1.14.2 should also be able to use this version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ The `sdkVersion` has been corrected from `1.15.0-rc.5` to `1.15.1` in `codelists
 
 ### Updates on Fields
 
-* Fixed the casing of `referencedBusinessEntityId` values in `fields.json`:
-  - `"organization"` → `"Organisation"` (in the BUYER instance identifier)
-  - `"contract"` → `"Contract"` (in the contract instance identifier)
+* Corrected the `referencedBusinessEntityId` values in `fields.json` to reference the business-entity id instead of the identifier-scheme id:
+  - `"organization"` → `"Organisation"` (in the `Buyer` instance identifier)
+  - `"contract"` → `"Contract"` (in the `ContractModification` instance identifier)
 
 <br>
 

--- a/codelists/applicability_reserved-execution.gc
+++ b/codelists/applicability_reserved-execution.gc
@@ -6,7 +6,7 @@
       <LongName>reserved-execution</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/applicability</LongName>
       <LongName Identifier="eFormsParentId">applicability</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/codelists.json
+++ b/codelists/codelists.json
@@ -1,13 +1,13 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"
   },
   "codelists" : [ {
     "id" : "accelerated-procedure",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "indicator",
     "filename" : "indicator_accelerated-procedure.gc",
     "description" : "List of codes to specify whether a procedure is accelerated or not.",
@@ -26,7 +26,7 @@
     "_label" : "codelist|name|applicability"
   }, {
     "id" : "authority-activity",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "main-activity",
     "filename" : "main-activity_authority-activity.gc",
     "description" : "List of Main Activity codes allowed for a Contracting Authority",
@@ -39,21 +39,21 @@
     "_label" : "codelist|name|award-criterion-type"
   }, {
     "id" : "bri",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-type",
     "filename" : "notice-type_bri.gc",
     "description" : "List of allowed Notice Type codes for a Business Register Information document",
     "_label" : "codelist|name|bri"
   }, {
     "id" : "brin-ecs",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-subtype",
     "filename" : "notice-subtype_brin-ecs.gc",
     "description" : "List of allowed Notice Subtype codes for a notice concerning a European Company or a European Cooperative Society registration processing.",
     "_label" : "codelist|name|brin-ecs"
   }, {
     "id" : "brin-eeig",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-subtype",
     "filename" : "notice-subtype_brin-eeig.gc",
     "description" : "List of allowed Notice Subtype codes for a notice concerning a European Economic Interest Grouping registration processing.",
@@ -78,35 +78,35 @@
     "_label" : "codelist|name|buyer-legal-type"
   }, {
     "id" : "can-desg",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-subtype",
     "filename" : "notice-subtype_can-desg.gc",
     "description" : "List of allowed Notice Subtype codes for a notice of CAN Design Notice Type.",
     "_label" : "codelist|name|can-desg"
   }, {
     "id" : "can-modif",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-subtype",
     "filename" : "notice-subtype_can-modif.gc",
     "description" : "List of allowed Notice Subtype codes for a notice of Contract Modification Notice Type .",
     "_label" : "codelist|name|can-modif"
   }, {
     "id" : "can-social",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-subtype",
     "filename" : "notice-subtype_can-social.gc",
     "description" : "List of allowed Notice Subtype codes for a notice of CAN Social Notice Type .",
     "_label" : "codelist|name|can-social"
   }, {
     "id" : "can-standard",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-subtype",
     "filename" : "notice-subtype_can-standard.gc",
     "description" : "List of allowed Notice Subtype codes for a notice of CAN Standard Notice Type .",
     "_label" : "codelist|name|can-standard"
   }, {
     "id" : "can-tran",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-subtype",
     "filename" : "notice-subtype_can-tran.gc",
     "description" : "List of allowed Notice Subtype codes for a notice of CAN Public Transport Service Notice Type .",
@@ -125,21 +125,21 @@
     "_label" : "codelist|name|classification-type"
   }, {
     "id" : "cn-desg",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-subtype",
     "filename" : "notice-subtype_cn-desg.gc",
     "description" : "List of allowed Notice Subtype codes for a notice of CN Design Notice Type.",
     "_label" : "codelist|name|cn-desg"
   }, {
     "id" : "cn-social",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-subtype",
     "filename" : "notice-subtype_cn-social.gc",
     "description" : "List of allowed Notice Subtype codes for a notice of CN Social Notice Type.",
     "_label" : "codelist|name|cn-social"
   }, {
     "id" : "cn-standard",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-subtype",
     "filename" : "notice-subtype_cn-standard.gc",
     "description" : "List of allowed Notice Subtype codes for a notice of CN Standard Design Notice Type.",
@@ -152,21 +152,21 @@
     "_label" : "codelist|name|communication-justification"
   }, {
     "id" : "competition",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-type",
     "filename" : "notice-type_competition.gc",
     "description" : "List of allowed Notice Type codes for a notice of Competition Form Type",
     "_label" : "codelist|name|competition"
   }, {
     "id" : "compl",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-subtype",
     "filename" : "notice-subtype_compl.gc",
     "description" : "List of allowed Notice Subtype codes for a Contract Completion Notice Type",
     "_label" : "codelist|name|compl"
   }, {
     "id" : "completion",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-type",
     "filename" : "notice-type_completion.gc",
     "description" : "List of allowed Notice Type codes for a Completion Form Type",
@@ -179,14 +179,14 @@
     "_label" : "codelist|name|conditions"
   }, {
     "id" : "consultation",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-type",
     "filename" : "notice-type_consultation.gc",
     "description" : "List of allowed Notice Type codes for a Consultation Form Type",
     "_label" : "codelist|name|consultation"
   }, {
     "id" : "cont-modif",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-type",
     "filename" : "notice-type_cont-modif.gc",
     "description" : "List of allowed Notice Type codes for a notice of Contract Modification Form Type",
@@ -205,7 +205,7 @@
     "_label" : "codelist|name|contract-nature"
   }, {
     "id" : "contract-term",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "contract-detail",
     "filename" : "contract-detail_contract-term.gc",
     "description" : "TODO",
@@ -254,14 +254,14 @@
     "_label" : "codelist|name|cvd-contract-type"
   }, {
     "id" : "cvd-scope",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "indicator",
     "filename" : "indicator_cvd-scope.gc",
     "description" : "List of codes to specify whether the procurement falls within the scope of the European Parliament and Council 2009/33/EC (Clean Vehicles Directive – CVD).",
     "_label" : "codelist|name|cvd-scope"
   }, {
     "id" : "dir-awa-pre",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-type",
     "filename" : "notice-type_dir-awa-pre.gc",
     "description" : "List of allowed Notice Type codes for a Direct Award Preannouncement Form Type",
@@ -298,21 +298,21 @@
     "_label" : "codelist|name|dps-usage"
   }, {
     "id" : "duration",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "timeperiod",
     "filename" : "timeperiod_duration.gc",
     "description" : "List of codes for undefined duration",
     "_label" : "codelist|name|duration"
   }, {
     "id" : "duration-unit",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "timeperiod",
     "filename" : "timeperiod_duration-unit.gc",
     "description" : "List of codes for eforms allowed duration unit of measure",
     "_label" : "codelist|name|duration-unit"
   }, {
     "id" : "ecatalog-submission",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "permission",
     "filename" : "permission_ecatalog-submission.gc",
     "description" : "List of codes to specify whether the submission of electronic catalogues is allowed or not.",
@@ -325,21 +325,21 @@
     "_label" : "codelist|name|economic-operator-size"
   }, {
     "id" : "eea-country",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "country",
     "filename" : "country_eea-country.gc",
     "description" : "List of codes of the European Economic Area countries",
     "_label" : "codelist|name|eea-country"
   }, {
     "id" : "eed-scope",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "indicator",
     "filename" : "indicator_eed-scope.gc",
     "description" : "This table provides the list of codes and values used to indicate that a procurement falls under the scope of the Energy Efficiency Directive",
     "_label" : "codelist|name|eed-scope"
   }, {
     "id" : "einvoicing",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "permission",
     "filename" : "permission_einvoicing.gc",
     "description" : "List of codes to specify whether the use of electronic invoicing is allowed or not.",
@@ -364,7 +364,7 @@
     "_label" : "codelist|name|energy-efficiency-label"
   }, {
     "id" : "entity-activity",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "main-activity",
     "filename" : "main-activity_entity-activity.gc",
     "description" : "List of Main Activity codes allowed for a Contracting Entity",
@@ -377,21 +377,21 @@
     "_label" : "codelist|name|environmental-impact"
   }, {
     "id" : "esignature-submission",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "indicator",
     "filename" : "indicator_esignature-submission.gc",
     "description" : "List of codes to dpecify whether electronic signature may be used or not.",
     "_label" : "codelist|name|esignature-submission"
   }, {
     "id" : "esubmission",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "permission",
     "filename" : "permission_esubmission.gc",
     "description" : "List of codes to specify whether the electronic submission is allowed or not.",
     "_label" : "codelist|name|esubmission"
   }, {
     "id" : "eu-country",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "country",
     "filename" : "country_eu-country.gc",
     "description" : "List of codes of the EU countries",
@@ -404,7 +404,7 @@
     "_label" : "codelist|name|eu-funded"
   }, {
     "id" : "eu-official-language",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "language",
     "filename" : "language_eu-official-language.gc",
     "description" : "List of codes of the EU official languages",
@@ -423,7 +423,7 @@
     "_label" : "codelist|name|exclusion-ground"
   }, {
     "id" : "exclusion-grounds-source",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "document-used-in-public-procurement",
     "filename" : "document-used-in-public-procurement_exclusion-grounds-source.gc",
     "description" : "Source for the exclusion grounds.",
@@ -448,7 +448,7 @@
     "_label" : "codelist|name|framework-agreement"
   }, {
     "id" : "fsr",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "indicator",
     "filename" : "indicator_fsr.gc",
     "description" : "List of codes to specify whether the Foreign Subsidies Regulation applies",
@@ -485,7 +485,7 @@
     "_label" : "codelist|name|international-procurement-instrument-measure"
   }, {
     "id" : "ipi-scope",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "indicator",
     "filename" : "indicator_ipi-scope.gc",
     "description" : "This table provides the list of codes and values used to indicate that a procurement falls under the scope of the International Procurement Instrument",
@@ -504,7 +504,7 @@
     "_label" : "codelist|name|language"
   }, {
     "id" : "lawful-country",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "country",
     "filename" : "country_lawful-country.gc",
     "description" : "List of countries for which there is a legal basis for publication in the Supplement to the Official Journal of the European Union",
@@ -517,364 +517,364 @@
     "_label" : "codelist|name|legal-basis"
   }, {
     "id" : "legal-basis-1",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-1.gc",
     "description" : "Allowed Legal Basis values for notice subtype 1",
     "_label" : "codelist|name|legal-basis-1"
   }, {
     "id" : "legal-basis-10",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-10.gc",
     "description" : "Allowed Legal Basis values for notice subtype 10",
     "_label" : "codelist|name|legal-basis-10"
   }, {
     "id" : "legal-basis-11",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-11.gc",
     "description" : "Allowed Legal Basis values for notice subtype 11",
     "_label" : "codelist|name|legal-basis-11"
   }, {
     "id" : "legal-basis-12",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-12.gc",
     "description" : "Allowed Legal Basis values for notice subtype 12",
     "_label" : "codelist|name|legal-basis-12"
   }, {
     "id" : "legal-basis-13",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-13.gc",
     "description" : "Allowed Legal Basis values for notice subtype 13",
     "_label" : "codelist|name|legal-basis-13"
   }, {
     "id" : "legal-basis-14",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-14.gc",
     "description" : "Allowed Legal Basis values for notice subtype 14",
     "_label" : "codelist|name|legal-basis-14"
   }, {
     "id" : "legal-basis-15",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-15.gc",
     "description" : "Allowed Legal Basis values for notice subtype 15",
     "_label" : "codelist|name|legal-basis-15"
   }, {
     "id" : "legal-basis-16",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-16.gc",
     "description" : "Allowed Legal Basis values for notice subtype 16",
     "_label" : "codelist|name|legal-basis-16"
   }, {
     "id" : "legal-basis-17",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-17.gc",
     "description" : "Allowed Legal Basis values for notice subtype 17",
     "_label" : "codelist|name|legal-basis-17"
   }, {
     "id" : "legal-basis-18",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-18.gc",
     "description" : "Allowed Legal Basis values for notice subtype 18",
     "_label" : "codelist|name|legal-basis-18"
   }, {
     "id" : "legal-basis-19",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-19.gc",
     "description" : "Allowed Legal Basis values for notice subtype 19",
     "_label" : "codelist|name|legal-basis-19"
   }, {
     "id" : "legal-basis-2",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-2.gc",
     "description" : "Allowed Legal Basis values for notice subtype 2",
     "_label" : "codelist|name|legal-basis-2"
   }, {
     "id" : "legal-basis-20",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-20.gc",
     "description" : "Allowed Legal Basis values for notice subtype 20",
     "_label" : "codelist|name|legal-basis-20"
   }, {
     "id" : "legal-basis-21",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-21.gc",
     "description" : "Allowed Legal Basis values for notice subtype 21",
     "_label" : "codelist|name|legal-basis-21"
   }, {
     "id" : "legal-basis-22",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-22.gc",
     "description" : "Allowed Legal Basis values for notice subtype 22",
     "_label" : "codelist|name|legal-basis-22"
   }, {
     "id" : "legal-basis-23",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-23.gc",
     "description" : "Allowed Legal Basis values for notice subtype 23",
     "_label" : "codelist|name|legal-basis-23"
   }, {
     "id" : "legal-basis-24",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-24.gc",
     "description" : "Allowed Legal Basis values for notice subtype 24",
     "_label" : "codelist|name|legal-basis-24"
   }, {
     "id" : "legal-basis-25",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-25.gc",
     "description" : "Allowed Legal Basis values for notice subtype 25",
     "_label" : "codelist|name|legal-basis-25"
   }, {
     "id" : "legal-basis-26",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-26.gc",
     "description" : "Allowed Legal Basis values for notice subtype 26",
     "_label" : "codelist|name|legal-basis-26"
   }, {
     "id" : "legal-basis-27",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-27.gc",
     "description" : "Allowed Legal Basis values for notice subtype 27",
     "_label" : "codelist|name|legal-basis-27"
   }, {
     "id" : "legal-basis-28",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-28.gc",
     "description" : "Allowed Legal Basis values for notice subtype 28",
     "_label" : "codelist|name|legal-basis-28"
   }, {
     "id" : "legal-basis-29",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-29.gc",
     "description" : "Allowed Legal Basis values for notice subtype 29",
     "_label" : "codelist|name|legal-basis-29"
   }, {
     "id" : "legal-basis-3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-3.gc",
     "description" : "Allowed Legal Basis values for notice subtype 3",
     "_label" : "codelist|name|legal-basis-3"
   }, {
     "id" : "legal-basis-30",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-30.gc",
     "description" : "Allowed Legal Basis values for notice subtype 30",
     "_label" : "codelist|name|legal-basis-30"
   }, {
     "id" : "legal-basis-31",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-31.gc",
     "description" : "Allowed Legal Basis values for notice subtype 31",
     "_label" : "codelist|name|legal-basis-31"
   }, {
     "id" : "legal-basis-32",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-32.gc",
     "description" : "Allowed Legal Basis values for notice subtype 32",
     "_label" : "codelist|name|legal-basis-32"
   }, {
     "id" : "legal-basis-33",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-33.gc",
     "description" : "Allowed Legal Basis values for notice subtype 33",
     "_label" : "codelist|name|legal-basis-33"
   }, {
     "id" : "legal-basis-34",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-34.gc",
     "description" : "Allowed Legal Basis values for notice subtype 34",
     "_label" : "codelist|name|legal-basis-34"
   }, {
     "id" : "legal-basis-35",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-35.gc",
     "description" : "Allowed Legal Basis values for notice subtype 35",
     "_label" : "codelist|name|legal-basis-35"
   }, {
     "id" : "legal-basis-36",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-36.gc",
     "description" : "Allowed Legal Basis values for notice subtype 36",
     "_label" : "codelist|name|legal-basis-36"
   }, {
     "id" : "legal-basis-37",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-37.gc",
     "description" : "Allowed Legal Basis values for notice subtype 37",
     "_label" : "codelist|name|legal-basis-37"
   }, {
     "id" : "legal-basis-38",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-38.gc",
     "description" : "Allowed Legal Basis values for notice subtype 38",
     "_label" : "codelist|name|legal-basis-38"
   }, {
     "id" : "legal-basis-39",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-39.gc",
     "description" : "Allowed Legal Basis values for notice subtype 39",
     "_label" : "codelist|name|legal-basis-39"
   }, {
     "id" : "legal-basis-4",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-4.gc",
     "description" : "Allowed Legal Basis values for notice subtype 4",
     "_label" : "codelist|name|legal-basis-4"
   }, {
     "id" : "legal-basis-40",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-40.gc",
     "description" : "Allowed Legal Basis values for notice subtype 40",
     "_label" : "codelist|name|legal-basis-40"
   }, {
     "id" : "legal-basis-5",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-5.gc",
     "description" : "Allowed Legal Basis values for notice subtype 5",
     "_label" : "codelist|name|legal-basis-5"
   }, {
     "id" : "legal-basis-6",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-6.gc",
     "description" : "Allowed Legal Basis values for notice subtype 6",
     "_label" : "codelist|name|legal-basis-6"
   }, {
     "id" : "legal-basis-7",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-7.gc",
     "description" : "Allowed Legal Basis values for notice subtype 7",
     "_label" : "codelist|name|legal-basis-7"
   }, {
     "id" : "legal-basis-8",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-8.gc",
     "description" : "Allowed Legal Basis values for notice subtype 8",
     "_label" : "codelist|name|legal-basis-8"
   }, {
     "id" : "legal-basis-9",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-9.gc",
     "description" : "Allowed Legal Basis values for notice subtype 9",
     "_label" : "codelist|name|legal-basis-9"
   }, {
     "id" : "legal-basis-cei",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-cei.gc",
     "description" : "Allowed Legal Basis values for notice subtype CEI",
     "_label" : "codelist|name|legal-basis-cei"
   }, {
     "id" : "legal-basis-e1",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-e1.gc",
     "description" : "Allowed Legal Basis values for notice subtype E1",
     "_label" : "codelist|name|legal-basis-e1"
   }, {
     "id" : "legal-basis-e2",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-e2.gc",
     "description" : "Allowed Legal Basis values for notice subtype E2",
     "_label" : "codelist|name|legal-basis-e2"
   }, {
     "id" : "legal-basis-e3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-e3.gc",
     "description" : "Allowed Legal Basis values for notice subtype E3",
     "_label" : "codelist|name|legal-basis-e3"
   }, {
     "id" : "legal-basis-e4",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-e4.gc",
     "description" : "Allowed Legal Basis values for notice subtype E4",
     "_label" : "codelist|name|legal-basis-e4"
   }, {
     "id" : "legal-basis-e5",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-e5.gc",
     "description" : "Allowed Legal Basis values for notice subtype E5",
     "_label" : "codelist|name|legal-basis-e5"
   }, {
     "id" : "legal-basis-e6",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-e6.gc",
     "description" : "Allowed Legal Basis values for notice subtype E6",
     "_label" : "codelist|name|legal-basis-e6"
   }, {
     "id" : "legal-basis-t01",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-t01.gc",
     "description" : "Allowed Legal Basis values for notice subtype T01",
     "_label" : "codelist|name|legal-basis-t01"
   }, {
     "id" : "legal-basis-t02",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-t02.gc",
     "description" : "Allowed Legal Basis values for notice subtype T02",
     "_label" : "codelist|name|legal-basis-t02"
   }, {
     "id" : "legal-basis-x01",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-x01.gc",
     "description" : "Allowed Legal Basis values for notice subtype X01",
     "_label" : "codelist|name|legal-basis-x01"
   }, {
     "id" : "legal-basis-x02",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "legal-basis",
     "filename" : "legal-basis_legal-basis-x02.gc",
     "description" : "Allowed Legal Basis values for notice subtype X02",
     "_label" : "codelist|name|legal-basis-x02"
   }, {
     "id" : "linguistic-status",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "document-status",
     "filename" : "document-status_linguistic-status.gc",
     "description" : "List of codes to specify whether a linguistic version has or not a legal status.",
@@ -911,14 +911,14 @@
     "_label" : "codelist|name|modification-justification"
   }, {
     "id" : "nda",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "indicator",
     "filename" : "indicator_nda.gc",
     "description" : "List of codes to specify whether a non-disclosure agreement is required.",
     "_label" : "codelist|name|nda"
   }, {
     "id" : "no-esubmission-justification",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "communication-justification",
     "filename" : "communication-justification_no-esubmission-justification.gc",
     "description" : "List of codes to justify the impossibility to submit electronically",
@@ -991,280 +991,280 @@
     "_label" : "codelist|name|nuts"
   }, {
     "id" : "nuts-alb-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-alb-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Albania",
     "_label" : "codelist|name|nuts-alb-lvl3"
   }, {
     "id" : "nuts-aut-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-aut-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Austria",
     "_label" : "codelist|name|nuts-aut-lvl3"
   }, {
     "id" : "nuts-bel-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-bel-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Belgium",
     "_label" : "codelist|name|nuts-bel-lvl3"
   }, {
     "id" : "nuts-bgr-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-bgr-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Bulgaria",
     "_label" : "codelist|name|nuts-bgr-lvl3"
   }, {
     "id" : "nuts-che-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-che-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Switzerland",
     "_label" : "codelist|name|nuts-che-lvl3"
   }, {
     "id" : "nuts-country",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "country",
     "filename" : "country_nuts-country.gc",
     "description" : "List of codes for Countries having NUTS codes",
     "_label" : "codelist|name|nuts-country"
   }, {
     "id" : "nuts-cyp-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-cyp-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Cyprus",
     "_label" : "codelist|name|nuts-cyp-lvl3"
   }, {
     "id" : "nuts-cze-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-cze-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Czech Republic",
     "_label" : "codelist|name|nuts-cze-lvl3"
   }, {
     "id" : "nuts-deu-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-deu-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Germany",
     "_label" : "codelist|name|nuts-deu-lvl3"
   }, {
     "id" : "nuts-dnk-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-dnk-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Denmark",
     "_label" : "codelist|name|nuts-dnk-lvl3"
   }, {
     "id" : "nuts-esp-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-esp-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Spain",
     "_label" : "codelist|name|nuts-esp-lvl3"
   }, {
     "id" : "nuts-est-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-est-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Estonia",
     "_label" : "codelist|name|nuts-est-lvl3"
   }, {
     "id" : "nuts-fin-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-fin-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Finland",
     "_label" : "codelist|name|nuts-fin-lvl3"
   }, {
     "id" : "nuts-fra-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-fra-lvl3.gc",
     "description" : "List of level 3 NUTS codes for France",
     "_label" : "codelist|name|nuts-fra-lvl3"
   }, {
     "id" : "nuts-grc-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-grc-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Greece",
     "_label" : "codelist|name|nuts-grc-lvl3"
   }, {
     "id" : "nuts-hrv-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-hrv-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Croatia",
     "_label" : "codelist|name|nuts-hrv-lvl3"
   }, {
     "id" : "nuts-hun-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-hun-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Hungary",
     "_label" : "codelist|name|nuts-hun-lvl3"
   }, {
     "id" : "nuts-irl-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-irl-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Ireland",
     "_label" : "codelist|name|nuts-irl-lvl3"
   }, {
     "id" : "nuts-isl-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-isl-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Iceland",
     "_label" : "codelist|name|nuts-isl-lvl3"
   }, {
     "id" : "nuts-ita-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-ita-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Italy",
     "_label" : "codelist|name|nuts-ita-lvl3"
   }, {
     "id" : "nuts-lie-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-lie-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Lichtenstein",
     "_label" : "codelist|name|nuts-lie-lvl3"
   }, {
     "id" : "nuts-ltu-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-ltu-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Lithuania",
     "_label" : "codelist|name|nuts-ltu-lvl3"
   }, {
     "id" : "nuts-lux-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-lux-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Luxembourg",
     "_label" : "codelist|name|nuts-lux-lvl3"
   }, {
     "id" : "nuts-lva-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-lva-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Latvia",
     "_label" : "codelist|name|nuts-lva-lvl3"
   }, {
     "id" : "nuts-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-lvl3.gc",
     "description" : "List of all level 3 NUTS codes",
     "_label" : "codelist|name|nuts-lvl3"
   }, {
     "id" : "nuts-mkd-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-mkd-lvl3.gc",
     "description" : "List of level 3 NUTS codes for North Macedonia",
     "_label" : "codelist|name|nuts-mkd-lvl3"
   }, {
     "id" : "nuts-mlt-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-mlt-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Malta",
     "_label" : "codelist|name|nuts-mlt-lvl3"
   }, {
     "id" : "nuts-mne-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-mne-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Montenegro",
     "_label" : "codelist|name|nuts-mne-lvl3"
   }, {
     "id" : "nuts-nld-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-nld-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Netherlands",
     "_label" : "codelist|name|nuts-nld-lvl3"
   }, {
     "id" : "nuts-nor-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-nor-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Norway",
     "_label" : "codelist|name|nuts-nor-lvl3"
   }, {
     "id" : "nuts-pol-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-pol-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Poland",
     "_label" : "codelist|name|nuts-pol-lvl3"
   }, {
     "id" : "nuts-prt-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-prt-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Portugal",
     "_label" : "codelist|name|nuts-prt-lvl3"
   }, {
     "id" : "nuts-rou-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-rou-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Romania",
     "_label" : "codelist|name|nuts-rou-lvl3"
   }, {
     "id" : "nuts-srb-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-srb-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Serbia",
     "_label" : "codelist|name|nuts-srb-lvl3"
   }, {
     "id" : "nuts-svk-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-svk-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Slovakia",
     "_label" : "codelist|name|nuts-svk-lvl3"
   }, {
     "id" : "nuts-svn-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-svn-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Slovenia",
     "_label" : "codelist|name|nuts-svn-lvl3"
   }, {
     "id" : "nuts-swe-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-swe-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Sweden",
     "_label" : "codelist|name|nuts-swe-lvl3"
   }, {
     "id" : "nuts-tur-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-tur-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Turkey",
     "_label" : "codelist|name|nuts-tur-lvl3"
   }, {
     "id" : "nuts-ukr-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-ukr-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Ukraine",
     "_label" : "codelist|name|nuts-ukr-lvl3"
   }, {
     "id" : "nuts-xkx-lvl3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "nuts",
     "filename" : "nuts_nuts-xkx-lvl3.gc",
     "description" : "List of level 3 NUTS codes for Kosovo",
@@ -1277,7 +1277,7 @@
     "_label" : "codelist|name|organisation-role"
   }, {
     "id" : "organisation-role-service",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "organisation-role",
     "filename" : "organisation-role_organisation-role-service.gc",
     "description" : "List of possible service codes for Procurement Service Providers",
@@ -1296,49 +1296,49 @@
     "_label" : "codelist|name|permission"
   }, {
     "id" : "pin-buyer",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-subtype",
     "filename" : "notice-subtype_pin-buyer.gc",
     "description" : "List of allowed Notice Subtype codes for a notice of PIN Buyer Notice Type.",
     "_label" : "codelist|name|pin-buyer"
   }, {
     "id" : "pin-cfc-social",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-subtype",
     "filename" : "notice-subtype_pin-cfc-social.gc",
     "description" : "List of allowed Notice Subtype codes for a notice of PIN Call for Competition Social Notice Type.",
     "_label" : "codelist|name|pin-cfc-social"
   }, {
     "id" : "pin-cfc-standard",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-subtype",
     "filename" : "notice-subtype_pin-cfc-standard.gc",
     "description" : "List of allowed Notice Subtype codes for a notice of PIN Call for Competition Standard Notice Type.",
     "_label" : "codelist|name|pin-cfc-standard"
   }, {
     "id" : "pin-only",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-subtype",
     "filename" : "notice-subtype_pin-only.gc",
     "description" : "List of allowed Notice Subtype codes for a notice of PIN Only Notice Type.",
     "_label" : "codelist|name|pin-only"
   }, {
     "id" : "pin-rtl",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-subtype",
     "filename" : "notice-subtype_pin-rtl.gc",
     "description" : "List of allowed Notice Subtype codes for a notice of PIN Reduced Time Limit Notice Type.",
     "_label" : "codelist|name|pin-rtl"
   }, {
     "id" : "pin-tran",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-subtype",
     "filename" : "notice-subtype_pin-tran.gc",
     "description" : "List of allowed Notice Subtype codes for a notice of PIN for Public Transportation Service Contract Notice Type.",
     "_label" : "codelist|name|pin-tran"
   }, {
     "id" : "planning",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-type",
     "filename" : "notice-type_planning.gc",
     "description" : "List of allowed Notice Type codes for a Planning Form Type",
@@ -1351,266 +1351,266 @@
     "_label" : "codelist|name|player-type"
   }, {
     "id" : "pmc",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-subtype",
     "filename" : "notice-subtype_pmc.gc",
     "description" : "List of allowed Notice Subtype codes for a Pre-market Consultation Notice Type",
     "_label" : "codelist|name|pmc"
   }, {
     "id" : "postcode-country",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "country",
     "filename" : "country_postcode-country.gc",
     "description" : "List of country codes for countries having postcodes and requiring their use",
     "_label" : "codelist|name|postcode-country"
   }, {
     "id" : "procedure-type-10",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-10.gc",
     "description" : "Allowed procedure type for notice subtype 10",
     "_label" : "codelist|name|procedure-type-10"
   }, {
     "id" : "procedure-type-11",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-11.gc",
     "description" : "Allowed procedure type for notice subtype 11",
     "_label" : "codelist|name|procedure-type-11"
   }, {
     "id" : "procedure-type-12",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-12.gc",
     "description" : "Allowed procedure type for notice subtype 12",
     "_label" : "codelist|name|procedure-type-12"
   }, {
     "id" : "procedure-type-13",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-13.gc",
     "description" : "Allowed procedure type for notice subtype 13",
     "_label" : "codelist|name|procedure-type-13"
   }, {
     "id" : "procedure-type-14",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-14.gc",
     "description" : "Allowed procedure type for notice subtype 14",
     "_label" : "codelist|name|procedure-type-14"
   }, {
     "id" : "procedure-type-15",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-15.gc",
     "description" : "Allowed procedure type for notice subtype 15",
     "_label" : "codelist|name|procedure-type-15"
   }, {
     "id" : "procedure-type-16",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-16.gc",
     "description" : "Allowed procedure type for notice subtype 16",
     "_label" : "codelist|name|procedure-type-16"
   }, {
     "id" : "procedure-type-17",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-17.gc",
     "description" : "Allowed procedure type for notice subtype 17",
     "_label" : "codelist|name|procedure-type-17"
   }, {
     "id" : "procedure-type-18",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-18.gc",
     "description" : "Allowed procedure type for notice subtype 18",
     "_label" : "codelist|name|procedure-type-18"
   }, {
     "id" : "procedure-type-19",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-19.gc",
     "description" : "Allowed procedure type for notice subtype 19",
     "_label" : "codelist|name|procedure-type-19"
   }, {
     "id" : "procedure-type-20",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-20.gc",
     "description" : "Allowed procedure type for notice subtype 20",
     "_label" : "codelist|name|procedure-type-20"
   }, {
     "id" : "procedure-type-21",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-21.gc",
     "description" : "Allowed procedure type for notice subtype 21",
     "_label" : "codelist|name|procedure-type-21"
   }, {
     "id" : "procedure-type-22",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-22.gc",
     "description" : "Allowed procedure type for notice subtype 22",
     "_label" : "codelist|name|procedure-type-22"
   }, {
     "id" : "procedure-type-23",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-23.gc",
     "description" : "Allowed procedure type for notice subtype 23",
     "_label" : "codelist|name|procedure-type-23"
   }, {
     "id" : "procedure-type-24",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-24.gc",
     "description" : "Allowed procedure type for notice subtype 24",
     "_label" : "codelist|name|procedure-type-24"
   }, {
     "id" : "procedure-type-25",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-25.gc",
     "description" : "Allowed procedure type for notice subtype 25",
     "_label" : "codelist|name|procedure-type-25"
   }, {
     "id" : "procedure-type-26",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-26.gc",
     "description" : "Allowed procedure type for notice subtype 26",
     "_label" : "codelist|name|procedure-type-26"
   }, {
     "id" : "procedure-type-27",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-27.gc",
     "description" : "Allowed procedure type for notice subtype 27",
     "_label" : "codelist|name|procedure-type-27"
   }, {
     "id" : "procedure-type-28",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-28.gc",
     "description" : "Allowed procedure type for notice subtype 28",
     "_label" : "codelist|name|procedure-type-28"
   }, {
     "id" : "procedure-type-29",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-29.gc",
     "description" : "Allowed procedure type for notice subtype 29",
     "_label" : "codelist|name|procedure-type-29"
   }, {
     "id" : "procedure-type-30",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-30.gc",
     "description" : "Allowed procedure type for notice subtype 30",
     "_label" : "codelist|name|procedure-type-30"
   }, {
     "id" : "procedure-type-31",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-31.gc",
     "description" : "Allowed procedure type for notice subtype 31",
     "_label" : "codelist|name|procedure-type-31"
   }, {
     "id" : "procedure-type-32",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-32.gc",
     "description" : "Allowed procedure type for notice subtype 32",
     "_label" : "codelist|name|procedure-type-32"
   }, {
     "id" : "procedure-type-33",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-33.gc",
     "description" : "Allowed procedure type for notice subtype 33",
     "_label" : "codelist|name|procedure-type-33"
   }, {
     "id" : "procedure-type-34",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-34.gc",
     "description" : "Allowed procedure type for notice subtype 34",
     "_label" : "codelist|name|procedure-type-34"
   }, {
     "id" : "procedure-type-35",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-35.gc",
     "description" : "Allowed procedure type for notice subtype 35",
     "_label" : "codelist|name|procedure-type-35"
   }, {
     "id" : "procedure-type-36",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-36.gc",
     "description" : "Allowed procedure type for notice subtype 36",
     "_label" : "codelist|name|procedure-type-36"
   }, {
     "id" : "procedure-type-37",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-37.gc",
     "description" : "Allowed procedure type for notice subtype 37",
     "_label" : "codelist|name|procedure-type-37"
   }, {
     "id" : "procedure-type-7",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-7.gc",
     "description" : "Allowed procedure type for notice subtype 7",
     "_label" : "codelist|name|procedure-type-7"
   }, {
     "id" : "procedure-type-8",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-8.gc",
     "description" : "Allowed procedure type for notice subtype 8",
     "_label" : "codelist|name|procedure-type-8"
   }, {
     "id" : "procedure-type-9",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-9.gc",
     "description" : "Allowed procedure type for notice subtype 9",
     "_label" : "codelist|name|procedure-type-9"
   }, {
     "id" : "procedure-type-e3",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-e3.gc",
     "description" : "Allowed procedure type for notice subtype E3",
     "_label" : "codelist|name|procedure-type-e3"
   }, {
     "id" : "procedure-type-e4",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-e4.gc",
     "description" : "Allowed procedure type for notice subtype E4",
     "_label" : "codelist|name|procedure-type-e4"
   }, {
     "id" : "procedure-type-e5",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-e5.gc",
     "description" : "Allowed procedure type for notice subtype E5",
     "_label" : "codelist|name|procedure-type-e5"
   }, {
     "id" : "procedure-type-t01",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-t01.gc",
     "description" : "Allowed procedure type for notice subtype T01",
     "_label" : "codelist|name|procedure-type-t01"
   }, {
     "id" : "procedure-type-t02",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "procurement-procedure-type",
     "filename" : "procurement-procedure-type_procedure-type-t02.gc",
     "description" : "Allowed procedure type for notice subtype T02",
@@ -1623,7 +1623,7 @@
     "_label" : "codelist|name|procurement-procedure-type"
   }, {
     "id" : "qu-sy",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-subtype",
     "filename" : "notice-subtype_qu-sy.gc",
     "description" : "List of allowed Notice Subtype codes for a notice of Qualification System Notice Type.",
@@ -1642,7 +1642,7 @@
     "_label" : "codelist|name|remedy-type"
   }, {
     "id" : "required",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "indicator",
     "filename" : "indicator_required.gc",
     "description" : "List of codes to specify whether the associated requirement applies or not.",
@@ -1655,7 +1655,7 @@
     "_label" : "codelist|name|requirement-stage"
   }, {
     "id" : "reserved-execution",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "applicability",
     "filename" : "applicability_reserved-execution.gc",
     "description" : "List of codes to express whether a contract execution is reserved or not.",
@@ -1668,14 +1668,14 @@
     "_label" : "codelist|name|reserved-procurement"
   }, {
     "id" : "result",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-type",
     "filename" : "notice-type_result.gc",
     "description" : "List of allowed Notice Type codes for a Result Form Type",
     "_label" : "codelist|name|result"
   }, {
     "id" : "revenue-allocation",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "contract-detail",
     "filename" : "contract-detail_revenue-allocation.gc",
     "description" : "Revenue allocation",
@@ -1700,7 +1700,7 @@
     "_label" : "codelist|name|review-information-type"
   }, {
     "id" : "review-requester-type",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "organisation-role",
     "filename" : "organisation-role_review-requester-type.gc",
     "description" : "Category of Stakeholders that requested a review",
@@ -1719,7 +1719,7 @@
     "_label" : "codelist|name|rewards-penalties"
   }, {
     "id" : "selection-criteria-source",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "document-used-in-public-procurement",
     "filename" : "document-used-in-public-procurement_selection-criteria-source.gc",
     "description" : "Source for the exclusion grounds.",
@@ -1738,7 +1738,7 @@
     "_label" : "codelist|name|social-objective"
   }, {
     "id" : "social-service-cpv",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "cpv",
     "filename" : "cpv_social-service-cpv.gc",
     "description" : "Codes for social service of CPV",
@@ -1751,14 +1751,14 @@
     "_label" : "codelist|name|strategic-procurement"
   }, {
     "id" : "subco",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-subtype",
     "filename" : "notice-subtype_subco.gc",
     "description" : "List of allowed Notice Subtype codes for a notice of Subcontracting Notice Type.",
     "_label" : "codelist|name|subco"
   }, {
     "id" : "subcontracting-allowed",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "indicator",
     "filename" : "indicator_subcontracting-allowed.gc",
     "description" : "List of codes to specify whether subcontracting is allowed or not.",
@@ -1777,7 +1777,7 @@
     "_label" : "codelist|name|subcontracting-obligation"
   }, {
     "id" : "tender-guarantee-required",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "indicator",
     "filename" : "indicator_tender-guarantee-required.gc",
     "description" : "List of codes to specify whether a Tender Guarantee is required or not.",
@@ -1814,7 +1814,7 @@
     "_label" : "codelist|name|usage"
   }, {
     "id" : "veat",
-    "version" : "1.15.0-rc.5",
+    "version" : "1.15.1",
     "parentId" : "notice-subtype",
     "filename" : "notice-subtype_veat.gc",
     "description" : "List of allowed Notice Subtype codes for a notice of Voluntary ex-ante Transparency Notice Type.",

--- a/codelists/communication-justification_no-esubmission-justification.gc
+++ b/codelists/communication-justification_no-esubmission-justification.gc
@@ -6,7 +6,7 @@
       <LongName>no-esubmission-justification</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/communication-justification</LongName>
       <LongName Identifier="eFormsParentId">communication-justification</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/contract-detail_contract-term.gc
+++ b/codelists/contract-detail_contract-term.gc
@@ -6,7 +6,7 @@
       <LongName>contract-term</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/contract-detail</LongName>
       <LongName Identifier="eFormsParentId">contract-detail</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/contract-detail_revenue-allocation.gc
+++ b/codelists/contract-detail_revenue-allocation.gc
@@ -6,7 +6,7 @@
       <LongName>revenue-allocation</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/contract-detail</LongName>
       <LongName Identifier="eFormsParentId">contract-detail</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/country_eea-country.gc
+++ b/codelists/country_eea-country.gc
@@ -6,7 +6,7 @@
       <LongName>eea-country</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/country</LongName>
       <LongName Identifier="eFormsParentId">country</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/country_eu-country.gc
+++ b/codelists/country_eu-country.gc
@@ -6,7 +6,7 @@
       <LongName>eu-country</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/country</LongName>
       <LongName Identifier="eFormsParentId">country</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/country_lawful-country.gc
+++ b/codelists/country_lawful-country.gc
@@ -6,7 +6,7 @@
       <LongName>lawful-country</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/country</LongName>
       <LongName Identifier="eFormsParentId">country</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/country_nuts-country.gc
+++ b/codelists/country_nuts-country.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-country</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/country</LongName>
       <LongName Identifier="eFormsParentId">country</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/country_postcode-country.gc
+++ b/codelists/country_postcode-country.gc
@@ -6,7 +6,7 @@
       <LongName>postcode-country</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/country</LongName>
       <LongName Identifier="eFormsParentId">country</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/cpv_social-service-cpv.gc
+++ b/codelists/cpv_social-service-cpv.gc
@@ -6,7 +6,7 @@
       <LongName>social-service-cpv</LongName>
       <LongName Identifier="listId">http://data.europa.eu/cpv/Cpv2008/Code</LongName>
       <LongName Identifier="eFormsParentId">cpv</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/document-status_linguistic-status.gc
+++ b/codelists/document-status_linguistic-status.gc
@@ -5,7 +5,7 @@
       <ShortName>LinguisticStatus</ShortName>
       <LongName>linguistic-status</LongName>
       <LongName Identifier="eFormsParentId">document-status</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/document-used-in-public-procurement_exclusion-grounds-source.gc
+++ b/codelists/document-used-in-public-procurement_exclusion-grounds-source.gc
@@ -5,7 +5,7 @@
       <ShortName>ExclusionGroundsSource</ShortName>
       <LongName>exclusion-grounds-source</LongName>
       <LongName Identifier="eFormsParentId">document-used-in-public-procurement</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/document-used-in-public-procurement_selection-criteria-source.gc
+++ b/codelists/document-used-in-public-procurement_selection-criteria-source.gc
@@ -5,7 +5,7 @@
       <ShortName>SelectionCriteriaSource</ShortName>
       <LongName>selection-criteria-source</LongName>
       <LongName Identifier="eFormsParentId">document-used-in-public-procurement</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/indicator_accelerated-procedure.gc
+++ b/codelists/indicator_accelerated-procedure.gc
@@ -5,7 +5,7 @@
       <ShortName>AcceleratedProcedure</ShortName>
       <LongName>accelerated-procedure</LongName>
       <LongName Identifier="eFormsParentId">indicator</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/indicator_cvd-scope.gc
+++ b/codelists/indicator_cvd-scope.gc
@@ -5,7 +5,7 @@
       <ShortName>CvdScope</ShortName>
       <LongName>cvd-scope</LongName>
       <LongName Identifier="eFormsParentId">indicator</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/indicator_eed-scope.gc
+++ b/codelists/indicator_eed-scope.gc
@@ -5,7 +5,7 @@
       <ShortName>EedScope</ShortName>
       <LongName>eed-scope</LongName>
       <LongName Identifier="eFormsParentId">indicator</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/indicator_esignature-submission.gc
+++ b/codelists/indicator_esignature-submission.gc
@@ -5,7 +5,7 @@
       <ShortName>EsignatureSubmission</ShortName>
       <LongName>esignature-submission</LongName>
       <LongName Identifier="eFormsParentId">indicator</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/indicator_fsr.gc
+++ b/codelists/indicator_fsr.gc
@@ -5,7 +5,7 @@
       <ShortName>Fsr</ShortName>
       <LongName>fsr</LongName>
       <LongName Identifier="eFormsParentId">indicator</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/indicator_ipi-scope.gc
+++ b/codelists/indicator_ipi-scope.gc
@@ -5,7 +5,7 @@
       <ShortName>IpiScope</ShortName>
       <LongName>ipi-scope</LongName>
       <LongName Identifier="eFormsParentId">indicator</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/indicator_nda.gc
+++ b/codelists/indicator_nda.gc
@@ -5,7 +5,7 @@
       <ShortName>Nda</ShortName>
       <LongName>nda</LongName>
       <LongName Identifier="eFormsParentId">indicator</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/indicator_required.gc
+++ b/codelists/indicator_required.gc
@@ -5,7 +5,7 @@
       <ShortName>Required</ShortName>
       <LongName>required</LongName>
       <LongName Identifier="eFormsParentId">indicator</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/indicator_subcontracting-allowed.gc
+++ b/codelists/indicator_subcontracting-allowed.gc
@@ -5,7 +5,7 @@
       <ShortName>SubcontractingAllowed</ShortName>
       <LongName>subcontracting-allowed</LongName>
       <LongName Identifier="eFormsParentId">indicator</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/indicator_tender-guarantee-required.gc
+++ b/codelists/indicator_tender-guarantee-required.gc
@@ -5,7 +5,7 @@
       <ShortName>TenderGuaranteeRequired</ShortName>
       <LongName>tender-guarantee-required</LongName>
       <LongName Identifier="eFormsParentId">indicator</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/language_eu-official-language.gc
+++ b/codelists/language_eu-official-language.gc
@@ -6,7 +6,7 @@
       <LongName>eu-official-language</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/language</LongName>
       <LongName Identifier="eFormsParentId">language</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-1.gc
+++ b/codelists/legal-basis_legal-basis-1.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-1</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-10.gc
+++ b/codelists/legal-basis_legal-basis-10.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-10</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-11.gc
+++ b/codelists/legal-basis_legal-basis-11.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-11</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-12.gc
+++ b/codelists/legal-basis_legal-basis-12.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-12</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-13.gc
+++ b/codelists/legal-basis_legal-basis-13.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-13</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-14.gc
+++ b/codelists/legal-basis_legal-basis-14.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-14</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-15.gc
+++ b/codelists/legal-basis_legal-basis-15.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-15</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-16.gc
+++ b/codelists/legal-basis_legal-basis-16.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-16</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-17.gc
+++ b/codelists/legal-basis_legal-basis-17.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-17</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-18.gc
+++ b/codelists/legal-basis_legal-basis-18.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-18</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-19.gc
+++ b/codelists/legal-basis_legal-basis-19.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-19</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-2.gc
+++ b/codelists/legal-basis_legal-basis-2.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-2</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-20.gc
+++ b/codelists/legal-basis_legal-basis-20.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-20</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-21.gc
+++ b/codelists/legal-basis_legal-basis-21.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-21</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-22.gc
+++ b/codelists/legal-basis_legal-basis-22.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-22</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-23.gc
+++ b/codelists/legal-basis_legal-basis-23.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-23</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-24.gc
+++ b/codelists/legal-basis_legal-basis-24.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-24</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-25.gc
+++ b/codelists/legal-basis_legal-basis-25.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-25</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-26.gc
+++ b/codelists/legal-basis_legal-basis-26.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-26</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-27.gc
+++ b/codelists/legal-basis_legal-basis-27.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-27</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-28.gc
+++ b/codelists/legal-basis_legal-basis-28.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-28</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-29.gc
+++ b/codelists/legal-basis_legal-basis-29.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-29</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-3.gc
+++ b/codelists/legal-basis_legal-basis-3.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-30.gc
+++ b/codelists/legal-basis_legal-basis-30.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-30</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-31.gc
+++ b/codelists/legal-basis_legal-basis-31.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-31</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-32.gc
+++ b/codelists/legal-basis_legal-basis-32.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-32</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-33.gc
+++ b/codelists/legal-basis_legal-basis-33.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-33</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-34.gc
+++ b/codelists/legal-basis_legal-basis-34.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-34</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-35.gc
+++ b/codelists/legal-basis_legal-basis-35.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-35</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-36.gc
+++ b/codelists/legal-basis_legal-basis-36.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-36</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-37.gc
+++ b/codelists/legal-basis_legal-basis-37.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-37</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-38.gc
+++ b/codelists/legal-basis_legal-basis-38.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-38</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-39.gc
+++ b/codelists/legal-basis_legal-basis-39.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-39</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-4.gc
+++ b/codelists/legal-basis_legal-basis-4.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-4</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-40.gc
+++ b/codelists/legal-basis_legal-basis-40.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-40</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-5.gc
+++ b/codelists/legal-basis_legal-basis-5.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-5</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-6.gc
+++ b/codelists/legal-basis_legal-basis-6.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-6</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-7.gc
+++ b/codelists/legal-basis_legal-basis-7.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-7</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-8.gc
+++ b/codelists/legal-basis_legal-basis-8.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-8</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-9.gc
+++ b/codelists/legal-basis_legal-basis-9.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-9</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-cei.gc
+++ b/codelists/legal-basis_legal-basis-cei.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-cei</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-e1.gc
+++ b/codelists/legal-basis_legal-basis-e1.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-e1</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-e2.gc
+++ b/codelists/legal-basis_legal-basis-e2.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-e2</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-e3.gc
+++ b/codelists/legal-basis_legal-basis-e3.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-e3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-e4.gc
+++ b/codelists/legal-basis_legal-basis-e4.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-e4</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-e5.gc
+++ b/codelists/legal-basis_legal-basis-e5.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-e5</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-e6.gc
+++ b/codelists/legal-basis_legal-basis-e6.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-e6</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-t01.gc
+++ b/codelists/legal-basis_legal-basis-t01.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-t01</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-t02.gc
+++ b/codelists/legal-basis_legal-basis-t02.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-t02</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-x01.gc
+++ b/codelists/legal-basis_legal-basis-x01.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-x01</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/legal-basis_legal-basis-x02.gc
+++ b/codelists/legal-basis_legal-basis-x02.gc
@@ -6,7 +6,7 @@
       <LongName>legal-basis-x02</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/legal-basis</LongName>
       <LongName Identifier="eFormsParentId">legal-basis</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/main-activity_authority-activity.gc
+++ b/codelists/main-activity_authority-activity.gc
@@ -6,7 +6,7 @@
       <LongName>authority-activity</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/main-activity</LongName>
       <LongName Identifier="eFormsParentId">main-activity</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/main-activity_entity-activity.gc
+++ b/codelists/main-activity_entity-activity.gc
@@ -6,7 +6,7 @@
       <LongName>entity-activity</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/main-activity</LongName>
       <LongName Identifier="eFormsParentId">main-activity</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-subtype_brin-ecs.gc
+++ b/codelists/notice-subtype_brin-ecs.gc
@@ -5,7 +5,7 @@
       <ShortName>BrinEcs</ShortName>
       <LongName>brin-ecs</LongName>
       <LongName Identifier="eFormsParentId">notice-subtype</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-subtype_brin-eeig.gc
+++ b/codelists/notice-subtype_brin-eeig.gc
@@ -5,7 +5,7 @@
       <ShortName>BrinEeig</ShortName>
       <LongName>brin-eeig</LongName>
       <LongName Identifier="eFormsParentId">notice-subtype</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-subtype_can-desg.gc
+++ b/codelists/notice-subtype_can-desg.gc
@@ -5,7 +5,7 @@
       <ShortName>CanDesg</ShortName>
       <LongName>can-desg</LongName>
       <LongName Identifier="eFormsParentId">notice-subtype</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-subtype_can-modif.gc
+++ b/codelists/notice-subtype_can-modif.gc
@@ -5,7 +5,7 @@
       <ShortName>CanModif</ShortName>
       <LongName>can-modif</LongName>
       <LongName Identifier="eFormsParentId">notice-subtype</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-subtype_can-social.gc
+++ b/codelists/notice-subtype_can-social.gc
@@ -5,7 +5,7 @@
       <ShortName>CanSocial</ShortName>
       <LongName>can-social</LongName>
       <LongName Identifier="eFormsParentId">notice-subtype</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-subtype_can-standard.gc
+++ b/codelists/notice-subtype_can-standard.gc
@@ -5,7 +5,7 @@
       <ShortName>CanStandard</ShortName>
       <LongName>can-standard</LongName>
       <LongName Identifier="eFormsParentId">notice-subtype</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-subtype_can-tran.gc
+++ b/codelists/notice-subtype_can-tran.gc
@@ -5,7 +5,7 @@
       <ShortName>CanTran</ShortName>
       <LongName>can-tran</LongName>
       <LongName Identifier="eFormsParentId">notice-subtype</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-subtype_cn-desg.gc
+++ b/codelists/notice-subtype_cn-desg.gc
@@ -5,7 +5,7 @@
       <ShortName>CnDesg</ShortName>
       <LongName>cn-desg</LongName>
       <LongName Identifier="eFormsParentId">notice-subtype</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-subtype_cn-social.gc
+++ b/codelists/notice-subtype_cn-social.gc
@@ -5,7 +5,7 @@
       <ShortName>CnSocial</ShortName>
       <LongName>cn-social</LongName>
       <LongName Identifier="eFormsParentId">notice-subtype</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-subtype_cn-standard.gc
+++ b/codelists/notice-subtype_cn-standard.gc
@@ -5,7 +5,7 @@
       <ShortName>CnStandard</ShortName>
       <LongName>cn-standard</LongName>
       <LongName Identifier="eFormsParentId">notice-subtype</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-subtype_compl.gc
+++ b/codelists/notice-subtype_compl.gc
@@ -5,7 +5,7 @@
       <ShortName>Contract Completion Notice</ShortName>
       <LongName>compl</LongName>
       <LongName Identifier="eFormsParentId">notice-subtype</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-subtype_pin-buyer.gc
+++ b/codelists/notice-subtype_pin-buyer.gc
@@ -5,7 +5,7 @@
       <ShortName>PinBuyer</ShortName>
       <LongName>pin-buyer</LongName>
       <LongName Identifier="eFormsParentId">notice-subtype</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-subtype_pin-cfc-social.gc
+++ b/codelists/notice-subtype_pin-cfc-social.gc
@@ -5,7 +5,7 @@
       <ShortName>PinCfcSocial</ShortName>
       <LongName>pin-cfc-social</LongName>
       <LongName Identifier="eFormsParentId">notice-subtype</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-subtype_pin-cfc-standard.gc
+++ b/codelists/notice-subtype_pin-cfc-standard.gc
@@ -5,7 +5,7 @@
       <ShortName>PinCfcStandard</ShortName>
       <LongName>pin-cfc-standard</LongName>
       <LongName Identifier="eFormsParentId">notice-subtype</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-subtype_pin-only.gc
+++ b/codelists/notice-subtype_pin-only.gc
@@ -5,7 +5,7 @@
       <ShortName>PinOnly</ShortName>
       <LongName>pin-only</LongName>
       <LongName Identifier="eFormsParentId">notice-subtype</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-subtype_pin-rtl.gc
+++ b/codelists/notice-subtype_pin-rtl.gc
@@ -5,7 +5,7 @@
       <ShortName>PinRtl</ShortName>
       <LongName>pin-rtl</LongName>
       <LongName Identifier="eFormsParentId">notice-subtype</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-subtype_pin-tran.gc
+++ b/codelists/notice-subtype_pin-tran.gc
@@ -5,7 +5,7 @@
       <ShortName>PinTran</ShortName>
       <LongName>pin-tran</LongName>
       <LongName Identifier="eFormsParentId">notice-subtype</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-subtype_pmc.gc
+++ b/codelists/notice-subtype_pmc.gc
@@ -5,7 +5,7 @@
       <ShortName>Pre-Market Consultation Notice</ShortName>
       <LongName>pmc</LongName>
       <LongName Identifier="eFormsParentId">notice-subtype</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-subtype_qu-sy.gc
+++ b/codelists/notice-subtype_qu-sy.gc
@@ -5,7 +5,7 @@
       <ShortName>QuSy</ShortName>
       <LongName>qu-sy</LongName>
       <LongName Identifier="eFormsParentId">notice-subtype</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-subtype_subco.gc
+++ b/codelists/notice-subtype_subco.gc
@@ -5,7 +5,7 @@
       <ShortName>Subco</ShortName>
       <LongName>subco</LongName>
       <LongName Identifier="eFormsParentId">notice-subtype</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-subtype_veat.gc
+++ b/codelists/notice-subtype_veat.gc
@@ -5,7 +5,7 @@
       <ShortName>Veat</ShortName>
       <LongName>veat</LongName>
       <LongName Identifier="eFormsParentId">notice-subtype</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-type_bri.gc
+++ b/codelists/notice-type_bri.gc
@@ -6,7 +6,7 @@
       <LongName>bri</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/notice-type</LongName>
       <LongName Identifier="eFormsParentId">notice-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-type_competition.gc
+++ b/codelists/notice-type_competition.gc
@@ -6,7 +6,7 @@
       <LongName>competition</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/notice-type</LongName>
       <LongName Identifier="eFormsParentId">notice-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-type_completion.gc
+++ b/codelists/notice-type_completion.gc
@@ -6,7 +6,7 @@
       <LongName>completion</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/notice-type</LongName>
       <LongName Identifier="eFormsParentId">notice-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-type_consultation.gc
+++ b/codelists/notice-type_consultation.gc
@@ -6,7 +6,7 @@
       <LongName>consultation</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/notice-type</LongName>
       <LongName Identifier="eFormsParentId">notice-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-type_cont-modif.gc
+++ b/codelists/notice-type_cont-modif.gc
@@ -6,7 +6,7 @@
       <LongName>cont-modif</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/notice-type</LongName>
       <LongName Identifier="eFormsParentId">notice-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-type_dir-awa-pre.gc
+++ b/codelists/notice-type_dir-awa-pre.gc
@@ -6,7 +6,7 @@
       <LongName>dir-awa-pre</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/notice-type</LongName>
       <LongName Identifier="eFormsParentId">notice-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-type_planning.gc
+++ b/codelists/notice-type_planning.gc
@@ -6,7 +6,7 @@
       <LongName>planning</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/notice-type</LongName>
       <LongName Identifier="eFormsParentId">notice-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/notice-type_result.gc
+++ b/codelists/notice-type_result.gc
@@ -6,7 +6,7 @@
       <LongName>result</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/notice-type</LongName>
       <LongName Identifier="eFormsParentId">notice-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-alb-lvl3.gc
+++ b/codelists/nuts_nuts-alb-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-alb-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-aut-lvl3.gc
+++ b/codelists/nuts_nuts-aut-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-aut-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-bel-lvl3.gc
+++ b/codelists/nuts_nuts-bel-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-bel-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-bgr-lvl3.gc
+++ b/codelists/nuts_nuts-bgr-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-bgr-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-che-lvl3.gc
+++ b/codelists/nuts_nuts-che-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-che-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-cyp-lvl3.gc
+++ b/codelists/nuts_nuts-cyp-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-cyp-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-cze-lvl3.gc
+++ b/codelists/nuts_nuts-cze-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-cze-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-deu-lvl3.gc
+++ b/codelists/nuts_nuts-deu-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-deu-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-dnk-lvl3.gc
+++ b/codelists/nuts_nuts-dnk-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-dnk-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-esp-lvl3.gc
+++ b/codelists/nuts_nuts-esp-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-esp-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-est-lvl3.gc
+++ b/codelists/nuts_nuts-est-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-est-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-fin-lvl3.gc
+++ b/codelists/nuts_nuts-fin-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-fin-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-fra-lvl3.gc
+++ b/codelists/nuts_nuts-fra-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-fra-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-grc-lvl3.gc
+++ b/codelists/nuts_nuts-grc-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-grc-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-hrv-lvl3.gc
+++ b/codelists/nuts_nuts-hrv-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-hrv-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-hun-lvl3.gc
+++ b/codelists/nuts_nuts-hun-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-hun-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-irl-lvl3.gc
+++ b/codelists/nuts_nuts-irl-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-irl-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-isl-lvl3.gc
+++ b/codelists/nuts_nuts-isl-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-isl-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-ita-lvl3.gc
+++ b/codelists/nuts_nuts-ita-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-ita-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-lie-lvl3.gc
+++ b/codelists/nuts_nuts-lie-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-lie-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-ltu-lvl3.gc
+++ b/codelists/nuts_nuts-ltu-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-ltu-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-lux-lvl3.gc
+++ b/codelists/nuts_nuts-lux-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-lux-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-lva-lvl3.gc
+++ b/codelists/nuts_nuts-lva-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-lva-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-mkd-lvl3.gc
+++ b/codelists/nuts_nuts-mkd-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-mkd-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-mlt-lvl3.gc
+++ b/codelists/nuts_nuts-mlt-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-mlt-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-mne-lvl3.gc
+++ b/codelists/nuts_nuts-mne-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-mne-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-nld-lvl3.gc
+++ b/codelists/nuts_nuts-nld-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-nld-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-nor-lvl3.gc
+++ b/codelists/nuts_nuts-nor-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-nor-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-pol-lvl3.gc
+++ b/codelists/nuts_nuts-pol-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-pol-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-prt-lvl3.gc
+++ b/codelists/nuts_nuts-prt-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-prt-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-rou-lvl3.gc
+++ b/codelists/nuts_nuts-rou-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-rou-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-srb-lvl3.gc
+++ b/codelists/nuts_nuts-srb-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-srb-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-svk-lvl3.gc
+++ b/codelists/nuts_nuts-svk-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-svk-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-svn-lvl3.gc
+++ b/codelists/nuts_nuts-svn-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-svn-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-swe-lvl3.gc
+++ b/codelists/nuts_nuts-swe-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-swe-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-tur-lvl3.gc
+++ b/codelists/nuts_nuts-tur-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-tur-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-ukr-lvl3.gc
+++ b/codelists/nuts_nuts-ukr-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-ukr-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/nuts_nuts-xkx-lvl3.gc
+++ b/codelists/nuts_nuts-xkx-lvl3.gc
@@ -6,7 +6,7 @@
       <LongName>nuts-xkx-lvl3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/nuts</LongName>
       <LongName Identifier="eFormsParentId">nuts</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/organisation-role_organisation-role-service.gc
+++ b/codelists/organisation-role_organisation-role-service.gc
@@ -6,7 +6,7 @@
       <LongName>organisation-role-service</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/organisation-role</LongName>
       <LongName Identifier="eFormsParentId">organisation-role</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/organisation-role_review-requester-type.gc
+++ b/codelists/organisation-role_review-requester-type.gc
@@ -6,7 +6,7 @@
       <LongName>review-requester-type</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/organisation-role</LongName>
       <LongName Identifier="eFormsParentId">organisation-role</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/permission_ecatalog-submission.gc
+++ b/codelists/permission_ecatalog-submission.gc
@@ -6,7 +6,7 @@
       <LongName>ecatalog-submission</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/permission</LongName>
       <LongName Identifier="eFormsParentId">permission</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/permission_einvoicing.gc
+++ b/codelists/permission_einvoicing.gc
@@ -6,7 +6,7 @@
       <LongName>einvoicing</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/permission</LongName>
       <LongName Identifier="eFormsParentId">permission</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/permission_esubmission.gc
+++ b/codelists/permission_esubmission.gc
@@ -6,7 +6,7 @@
       <LongName>esubmission</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/permission</LongName>
       <LongName Identifier="eFormsParentId">permission</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-10.gc
+++ b/codelists/procurement-procedure-type_procedure-type-10.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-10</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-11.gc
+++ b/codelists/procurement-procedure-type_procedure-type-11.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-11</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-12.gc
+++ b/codelists/procurement-procedure-type_procedure-type-12.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-12</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-13.gc
+++ b/codelists/procurement-procedure-type_procedure-type-13.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-13</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-14.gc
+++ b/codelists/procurement-procedure-type_procedure-type-14.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-14</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-15.gc
+++ b/codelists/procurement-procedure-type_procedure-type-15.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-15</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-16.gc
+++ b/codelists/procurement-procedure-type_procedure-type-16.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-16</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-17.gc
+++ b/codelists/procurement-procedure-type_procedure-type-17.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-17</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-18.gc
+++ b/codelists/procurement-procedure-type_procedure-type-18.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-18</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-19.gc
+++ b/codelists/procurement-procedure-type_procedure-type-19.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-19</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-20.gc
+++ b/codelists/procurement-procedure-type_procedure-type-20.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-20</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-21.gc
+++ b/codelists/procurement-procedure-type_procedure-type-21.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-21</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-22.gc
+++ b/codelists/procurement-procedure-type_procedure-type-22.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-22</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-23.gc
+++ b/codelists/procurement-procedure-type_procedure-type-23.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-23</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-24.gc
+++ b/codelists/procurement-procedure-type_procedure-type-24.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-24</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-25.gc
+++ b/codelists/procurement-procedure-type_procedure-type-25.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-25</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-26.gc
+++ b/codelists/procurement-procedure-type_procedure-type-26.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-26</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-27.gc
+++ b/codelists/procurement-procedure-type_procedure-type-27.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-27</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-28.gc
+++ b/codelists/procurement-procedure-type_procedure-type-28.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-28</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-29.gc
+++ b/codelists/procurement-procedure-type_procedure-type-29.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-29</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-30.gc
+++ b/codelists/procurement-procedure-type_procedure-type-30.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-30</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-31.gc
+++ b/codelists/procurement-procedure-type_procedure-type-31.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-31</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-32.gc
+++ b/codelists/procurement-procedure-type_procedure-type-32.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-32</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-33.gc
+++ b/codelists/procurement-procedure-type_procedure-type-33.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-33</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-34.gc
+++ b/codelists/procurement-procedure-type_procedure-type-34.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-34</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-35.gc
+++ b/codelists/procurement-procedure-type_procedure-type-35.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-35</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-36.gc
+++ b/codelists/procurement-procedure-type_procedure-type-36.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-36</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-37.gc
+++ b/codelists/procurement-procedure-type_procedure-type-37.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-37</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-7.gc
+++ b/codelists/procurement-procedure-type_procedure-type-7.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-7</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-8.gc
+++ b/codelists/procurement-procedure-type_procedure-type-8.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-8</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-9.gc
+++ b/codelists/procurement-procedure-type_procedure-type-9.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-9</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-e3.gc
+++ b/codelists/procurement-procedure-type_procedure-type-e3.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-e3</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-e4.gc
+++ b/codelists/procurement-procedure-type_procedure-type-e4.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-e4</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-e5.gc
+++ b/codelists/procurement-procedure-type_procedure-type-e5.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-e5</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-t01.gc
+++ b/codelists/procurement-procedure-type_procedure-type-t01.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-t01</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/procurement-procedure-type_procedure-type-t02.gc
+++ b/codelists/procurement-procedure-type_procedure-type-t02.gc
@@ -6,7 +6,7 @@
       <LongName>procedure-type-t02</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/procurement-procedure-type</LongName>
       <LongName Identifier="eFormsParentId">procurement-procedure-type</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/timeperiod_duration-unit.gc
+++ b/codelists/timeperiod_duration-unit.gc
@@ -6,7 +6,7 @@
       <LongName>duration-unit</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/timeperiod</LongName>
       <LongName Identifier="eFormsParentId">timeperiod</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/codelists/timeperiod_duration.gc
+++ b/codelists/timeperiod_duration.gc
@@ -6,7 +6,7 @@
       <LongName>duration</LongName>
       <LongName Identifier="listId">http://publications.europa.eu/resource/authority/timeperiod</LongName>
       <LongName Identifier="eFormsParentId">timeperiod</LongName>
-      <Version>1.15.0-rc.5</Version>
+      <Version>1.15.1</Version>
       <CanonicalUri/>
       <CanonicalVersionUri/>
       <Agency>

--- a/fields/fields.json
+++ b/fields/fields.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "eforms-sdk-1.15.0",
+  "sdkVersion" : "eforms-sdk-1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/fields/fields.json
+++ b/fields/fields.json
@@ -80,7 +80,7 @@
       "changeIdentifier" : "BUYER"
     },
     "instanceIdentifier" : {
-      "referencedBusinessEntityId" : "organization",
+      "referencedBusinessEntityId" : "Organisation",
       "identifierFieldId" : "OPT-300-Procedure-Buyer",
       "captionFieldId" : "BT-500-Organization-Company"
     }
@@ -231,7 +231,7 @@
       "useInstanceIdentifier" : true
     },
     "instanceIdentifier" : {
-      "referencedBusinessEntityId" : "contract",
+      "referencedBusinessEntityId" : "Contract",
       "identifierFieldId" : "BT-1501(c)-Contract",
       "captionFieldId" : "BT-150-Contract"
     }

--- a/fields/fields.json
+++ b/fields/fields.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "eforms-sdk-1.15.1",
+  "sdkVersion" : "eforms-sdk-1.16.0-SNAPSHOT",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/1.json
+++ b/notice-types/1.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/10.json
+++ b/notice-types/10.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/11.json
+++ b/notice-types/11.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/12.json
+++ b/notice-types/12.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/13.json
+++ b/notice-types/13.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/14.json
+++ b/notice-types/14.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/15.json
+++ b/notice-types/15.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/16.json
+++ b/notice-types/16.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/17.json
+++ b/notice-types/17.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/18.json
+++ b/notice-types/18.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/19.json
+++ b/notice-types/19.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/2.json
+++ b/notice-types/2.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/20.json
+++ b/notice-types/20.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/21.json
+++ b/notice-types/21.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/22.json
+++ b/notice-types/22.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/23.json
+++ b/notice-types/23.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/24.json
+++ b/notice-types/24.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/25.json
+++ b/notice-types/25.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/26.json
+++ b/notice-types/26.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/27.json
+++ b/notice-types/27.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/28.json
+++ b/notice-types/28.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/29.json
+++ b/notice-types/29.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/3.json
+++ b/notice-types/3.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/30.json
+++ b/notice-types/30.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/31.json
+++ b/notice-types/31.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/32.json
+++ b/notice-types/32.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/33.json
+++ b/notice-types/33.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/34.json
+++ b/notice-types/34.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/35.json
+++ b/notice-types/35.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/36.json
+++ b/notice-types/36.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/37.json
+++ b/notice-types/37.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/38.json
+++ b/notice-types/38.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/39.json
+++ b/notice-types/39.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/4.json
+++ b/notice-types/4.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/40.json
+++ b/notice-types/40.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/5.json
+++ b/notice-types/5.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/6.json
+++ b/notice-types/6.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/7.json
+++ b/notice-types/7.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/8.json
+++ b/notice-types/8.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/9.json
+++ b/notice-types/9.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/CEI.json
+++ b/notice-types/CEI.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/E1.json
+++ b/notice-types/E1.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/E2.json
+++ b/notice-types/E2.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/E3.json
+++ b/notice-types/E3.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/E4.json
+++ b/notice-types/E4.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/E5.json
+++ b/notice-types/E5.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/E6.json
+++ b/notice-types/E6.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/T01.json
+++ b/notice-types/T01.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/T02.json
+++ b/notice-types/T02.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/X01.json
+++ b/notice-types/X01.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/X02.json
+++ b/notice-types/X02.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/notice-types/notice-types.json
+++ b/notice-types/notice-types.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>eu.europa.ted.eforms</groupId>
   <artifactId>eforms-sdk</artifactId>
-  <version>1.15.1</version>
+  <version>1.16.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>eForms SDK</name>
@@ -40,7 +40,7 @@
     <project.build.outputTimestamp>2026-07-15T13:00:57Z</project.build.outputTimestamp>
 
     <!-- Versions eForms -->
-    <version.eforms-sdk-analyzer>1.15.1</version.eforms-sdk-analyzer>
+    <version.eforms-sdk-analyzer>1.16.0-SNAPSHOT</version.eforms-sdk-analyzer>
 
     <!-- Versions - Plugins -->
     <version.dependency.plugin>3.5.0</version.dependency.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>eu.europa.ted.eforms</groupId>
   <artifactId>eforms-sdk</artifactId>
-  <version>1.15.0</version>
+  <version>1.15.1</version>
   <packaging>jar</packaging>
 
   <name>eForms SDK</name>
@@ -40,7 +40,7 @@
     <project.build.outputTimestamp>2026-07-15T13:00:57Z</project.build.outputTimestamp>
 
     <!-- Versions eForms -->
-    <version.eforms-sdk-analyzer>1.15.0-SNAPSHOT</version.eforms-sdk-analyzer>
+    <version.eforms-sdk-analyzer>1.15.1</version.eforms-sdk-analyzer>
 
     <!-- Versions - Plugins -->
     <version.dependency.plugin>3.5.0</version.dependency.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>eu.europa.ted.eforms</groupId>
   <artifactId>eforms-sdk</artifactId>
-  <version>1.15.0</version>
+  <version>1.15.1</version>
   <packaging>jar</packaging>
 
   <name>eForms SDK</name>
@@ -40,7 +40,7 @@
     <project.build.outputTimestamp>2026-07-15T13:00:57Z</project.build.outputTimestamp>
 
     <!-- Versions eForms -->
-    <version.eforms-sdk-analyzer>1.15.0-SNAPSHOT</version.eforms-sdk-analyzer>
+    <version.eforms-sdk-analyzer>1.15.0</version.eforms-sdk-analyzer>
 
     <!-- Versions - Plugins -->
     <version.dependency.plugin>3.5.0</version.dependency.plugin>

--- a/view-templates/view-templates.json
+++ b/view-templates/view-templates.json
@@ -1,6 +1,6 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.15.0-rc.5",
+  "sdkVersion" : "1.15.1",
   "metadataDatabase" : {
     "version" : "1.14.44",
     "createdOn" : "2026-07-09T15:39:38"


### PR DESCRIPTION
Back-merges the released SDK **1.15.1** (from `main`) into `develop` and opens the next development iteration by bumping to **1.16.0-SNAPSHOT** in a single PR.

## Brings over from 1.15.1
- Version-stamp correction (rc.5 → 1.15.1) across codelists, notice-types, view-templates.
- `fields.json` fix ([TEDEFO-5124](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/TEDEFO-5124)): `referencedBusinessEntityId` now uses the business-entity id.
- CHANGELOG 1.15.1 section.

## Development bump (this branch)
- `pom.xml` version `1.15.1` → `1.16.0-SNAPSHOT`
- `pom.xml` analyzer `1.15.1` → `1.16.0-SNAPSHOT`
- `fields.json` sdkVersion `eforms-sdk-1.15.1` → `eforms-sdk-1.16.0-SNAPSHOT`

Content stamps (codelists / notice-types / view-templates) stay at 1.15.1; they are re-stamped at the next release export.