### PR TITLE
ci: publish releases only from validated merged tags

### DIFF
--- a/.github/scripts/validate-publication.sh
+++ b/.github/scripts/validate-publication.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+fail() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+publish() {
+  echo "publish=true" >> "${GITHUB_OUTPUT}"
+}
+
+skip() {
+  echo "publish=false" >> "${GITHUB_OUTPUT}"
+  echo "::notice::$*"
+}
+
+validate_release_source() {
+  [[ -n "${GITHUB_TOKEN:-}" ]] || fail "GITHUB_TOKEN is required to validate a release."
+  [[ -n "${GITHUB_API_URL:-}" ]] || fail "GITHUB_API_URL is required to validate a release."
+  [[ -n "${GITHUB_REPOSITORY:-}" ]] || fail "GITHUB_REPOSITORY is required to validate a release."
+  [[ -n "${GITHUB_SHA:-}" ]] || fail "GITHUB_SHA is required to validate a release."
+
+  local pulls
+  pulls="$(curl --fail-with-body --silent --show-error --location \
+    --header "Accept: application/vnd.github+json" \
+    --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+    --header "X-GitHub-Api-Version: 2022-11-28" \
+    "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls")"
+
+  local -a candidates
+  mapfile -t candidates < <(
+    jq --raw-output --arg sha "${GITHUB_SHA}" '
+      .[]
+      | select(.merged_at != null and .merge_commit_sha == $sha)
+      | select(
+          (((.base.ref == "develop") or (.base.ref == "efx-2"))
+            and (.head.ref | startswith("prepare/")))
+          or
+          ((.base.ref == "main") and (.head.ref | startswith("release/")))
+        )
+      | [.number, .base.ref, .head.ref]
+      | @tsv
+    ' <<< "${pulls}"
+  )
+
+  if [[ "${#candidates[@]}" -ne 1 ]]; then
+    fail "The release commit must be the merge commit of exactly one recognized release PR flow. Found ${#candidates[@]}."
+  fi
+
+  local pr_number target_branch source_branch
+  IFS=$'\t' read -r pr_number target_branch source_branch <<< "${candidates[0]}"
+
+  git fetch --no-tags origin \
+    "refs/heads/${target_branch}:refs/remotes/origin/${target_branch}"
+  if ! git merge-base --is-ancestor "${GITHUB_SHA}" "refs/remotes/origin/${target_branch}"; then
+    fail "Release commit ${GITHUB_SHA} is not contained in ${target_branch}."
+  fi
+
+  echo "::notice::Validated merged PR #${pr_number}: ${source_branch} -> ${target_branch}."
+}
+
+[[ -n "${PROJECT_VERSION:-}" ]] || fail "PROJECT_VERSION is required."
+[[ -n "${GITHUB_EVENT_NAME:-}" ]] || fail "GITHUB_EVENT_NAME is required."
+[[ -n "${GITHUB_OUTPUT:-}" ]] || fail "GITHUB_OUTPUT is required."
+
+is_snapshot=false
+if [[ "${PROJECT_VERSION}" == *-SNAPSHOT ]]; then
+  is_snapshot=true
+fi
+
+case "${GITHUB_EVENT_NAME}" in
+  push)
+    if [[ "${is_snapshot}" == true ]]; then
+      publish
+    else
+      skip "Skipping release deployment for development-branch push of ${PROJECT_VERSION}. Publish its validated GitHub release instead."
+    fi
+    ;;
+
+  release)
+    [[ "${is_snapshot}" == false ]] || fail "A GitHub release cannot publish SNAPSHOT version ${PROJECT_VERSION}."
+    [[ -n "${RELEASE_TAG_NAME:-}" ]] || fail "The published release has no tag name."
+    [[ "${RELEASE_TAG_NAME}" == "${PROJECT_VERSION}" ]] || \
+      fail "Release tag ${RELEASE_TAG_NAME} does not match POM version ${PROJECT_VERSION}."
+    [[ "${GITHUB_REF_TYPE:-}" == "tag" ]] || fail "A published release must run from a tag ref."
+    [[ "${GITHUB_REF_NAME:-}" == "${RELEASE_TAG_NAME}" ]] || \
+      fail "Workflow ref ${GITHUB_REF_NAME:-<unset>} does not match release tag ${RELEASE_TAG_NAME}."
+    validate_release_source
+    publish
+    ;;
+
+  workflow_dispatch)
+    [[ "${is_snapshot}" == true ]] || \
+      fail "Manual dispatch may publish snapshots only. Rerun the validated release workflow for a release version."
+    [[ "${GITHUB_REF_TYPE:-}" == "branch" ]] || \
+      fail "Manual snapshot publication must run from a development branch."
+    if [[ "${GITHUB_REF_NAME:-}" != "develop" && "${GITHUB_REF_NAME:-}" != "efx-2" ]]; then
+      fail "Manual snapshot publication is limited to develop or efx-2."
+    fi
+    publish
+    ;;
+
+  *)
+    fail "Unsupported publication event ${GITHUB_EVENT_NAME}."
+    ;;
+esac

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,10 @@ on:
       - 'develop'
 
   release:
-    types: [created]
+    # 'published' fires when a release is published, including when a draft
+    # is published. 'created' does not fire for draft-then-publish, so it
+    # would miss releases prepared as drafts.
+    types: [published]
 
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'develop'
+      - 'efx-2'
 
   release:
     # 'published' fires when a release is published, including when a draft
@@ -20,13 +21,11 @@ jobs:
     permissions:
       contents: read
       packages: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
-      - name: Import GPG Key
-        uses: crazy-max/ghaction-import-gpg@v6
         with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          fetch-depth: 0
       - name: Set up Java for publishing to Maven Central Repository
         uses: actions/setup-java@v4
         with:
@@ -35,9 +34,36 @@ jobs:
           server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
+      - name: Read project version
+        id: project
+        shell: bash
+        run: |
+          version="$(mvn --batch-mode help:evaluate \
+            -Dexpression=project.version \
+            -DforceStdout \
+            -q)"
+          if [[ -z "${version}" || "${version}" == *$'\n'* ]]; then
+            echo "::error::Could not resolve one project version from pom.xml."
+            exit 1
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+      - name: Validate publication context
+        id: publication
+        shell: bash
+        env:
+          PROJECT_VERSION: ${{ steps.project.outputs.version }}
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/validate-publication.sh
+      - name: Import GPG Key
+        if: steps.publication.outputs.publish == 'true'
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
       - name: Publish to the Maven Central Repository
+        if: steps.publication.outputs.publish == 'true'
         run: mvn --batch-mode deploy -Dgpg.passphrase='${{ secrets.GPG_PASSPHRASE }}' -Prelease
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-


### PR DESCRIPTION
## Purpose

Align Maven Central publication with the approved release sequence tracked by
[TEDEFO-5172](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/TEDEFO-5172):

1. merge the reviewed release-preparation PR;
2. tag the exact merged commit;
3. publish the GitHub release and Maven coordinates once;
4. only then return the development line to a snapshot.

The previous workflow ran the same unconditional `mvn deploy` both when a release
version was pushed to a development branch and when its GitHub release was created.
The merge therefore published first, and the release event attempted the immutable
coordinates a second time.

## Behaviour in this PR

| Event | Project version | Result |
| --- | --- | --- |
| Push to `develop` or `efx-2` | `*-SNAPSHOT` | Publish the snapshot |
| Push to `develop` or `efx-2` | non-snapshot | Succeed without deploying; wait for the GitHub release |
| GitHub release `published` | non-snapshot | Validate the tag and merged PR, then publish |
| GitHub release `published` | snapshot | Fail before secrets or deployment |
| Manual dispatch from `develop`/`efx-2` | snapshot | Publish the snapshot for exceptional recovery |
| Any manual non-snapshot dispatch or other ref | any | Fail before secrets or deployment |

For a GitHub release, the workflow now requires:

- the release tag to equal the Maven project version;
- the workflow to be running from that tag;
- the tagged SHA to be the merge commit of exactly one recognized release PR flow;
- `prepare/*` into `develop` or `efx-2` for alpha/beta releases, or
  `release/*` into `main` for final releases;
- the merge commit to remain contained in the target branch.

This prevents an unmerged `prepare/*` commit from being published. GPG material and
Central credentials are not used unless the validation chooses a valid deployment
path.

## Validation performed

- Actionlint: pass
- ShellCheck: pass
- Workflow YAML and shell syntax: pass
- Maven `project.version` resolution: pass
- Event matrix: snapshot pushes publish; non-snapshot pushes skip; unsafe manual and
  release combinations fail
- Historical merged-commit checks:
  - SDK 1 PR #1415 (`1.16.0-beta.2`): accepted
  - SDK 2 PR #1413 (`2.0.0-alpha.3`): accepted
  - final SDK PR #1400 (`1.15.1`): accepted
  - unmerged beta.1 prepare commit `40e7cf4f`: rejected

These checks exercise selection and validation only; they do not perform a Maven
deployment.

## Two-branch rollout

This PR targets `develop`. The identical `efx-2` change is in companion PR #1421;
otherwise pushes on that branch would continue using its old workflow definition.
Do not consider TEDEFO-5172 delivered until both PRs have landed on their respective
base branches and been verified.
