### PR TITLE
TEDEFO-5141: Add selector-block to the EFX-1 grammar

### DIFF
--- a/efx-grammar/Efx.g4
+++ b/efx-grammar/Efx.g4
@@ -11,7 +11,7 @@ options { tokenVocab=EfxLexer;}
  * Currently we only allow a field-identifier or a node-identifier in the context-declaration.
  * We may also add support for adding one or more predicates to the context-declaration in the future.
  */
-singleExpression: StartExpression (FieldId | NodeId) (Comma parameterList)? EndExpression expressionBlock EOF;
+singleExpression: StartExpression (FieldId | NodeId) (Comma parameterList)? EndExpression (expressionBlock | selectorBlock) EOF;
 
 /* 
  * A template-file is a series of template-lines.
@@ -85,6 +85,23 @@ otherAssetId: OtherAssetId | AssetType | LabelType;
 expressionBlock
     : StartExpression expression EndExpression          # standardExpressionBlock
     | ShorthandFieldValueReferenceFromContextField      # shorthandFieldValueReferenceFromContextField
+    ;
+
+/*
+ * A selector-block starts with & and contains, inside curly braces, a reference to the XML
+ * element(s) it designates. Unlike an expression-block, which yields the value of what it
+ * references, a selector-block yields the reference itself: the translated selector identifies
+ * the elements rather than reading them. It exists so that a host application can ask EFX where
+ * something is, instead of what it contains.
+ * A selector-block may only appear at the top level; it is not an expression and cannot be
+ * nested inside one.
+ */
+selectorBlock: StartSelector selection EndExpression;
+
+selection
+    : fieldContext
+    | nodeContext
+    | attributeReference
     ;
 
 /*

--- a/efx-grammar/EfxLexer.g4
+++ b/efx-grammar/EfxLexer.g4
@@ -84,6 +84,7 @@ fragment Char: ~[\r\n\f\t #$}{];
 fragment Dollar: '$';	// Used for label placeholders
 fragment Sharp: '#';	// Used for expression placeholders
 fragment OpenBrace: '{';
+fragment Ampersand: '&';	// Used for selector blocks
 
 ShorthandFieldValueReferenceFromContextField: Dollar ValueKeyword;
 ShorthandIndirectLabelReferenceFromContextField: Sharp ValueKeyword;
@@ -94,6 +95,7 @@ ShorthandLabelType: LabelType -> type(LabelType);
 
 StartExpression: Dollar OpenBrace -> pushMode(EXPRESSION);
 StartLabel: Sharp OpenBrace -> pushMode(LABEL);
+StartSelector: Ampersand OpenBrace -> pushMode(EXPRESSION);
 
 // Comments at the end of a line.
 EndOfLineComment: Whitespace* '//' ~[\r\n\f]* -> skip;


### PR DESCRIPTION
This pull request adds a selector-block to the EFX-1 grammar, so that an expression can identify XML elements rather than read their value.

The property privacy.undisclosedFieldSelector, introduced in SDK 1.16, has to identify the elements to be withheld. EFX-1 could not express this, because a field reference in an expression is always transpiled to the value of the field. The property therefore produced a sequence of values instead of a set of elements.

A selector is written after the context declaration:

    {ND-Root} &{/BT-500-Organization-Company[...]}

It yields the same path that the equivalent expression would use, without the final step that reads the value. It is relative or absolute according to how the reference is written, as elsewhere in the language.

The change is additive. The rule singleExpression accepts a selector-block as an alternative to an expression-block, and the selector-block admits a field, node or attribute reference, all three of which were already defined in the grammar. One token is added to the lexer. No existing rule or token is modified. The ampersand is not excluded from template free text, so templates that contain one continue to parse.

The full EFX Toolkit test suite passes against this grammar, and the transpiled output of the existing corpus is unchanged.

Support in the toolkit, TEDEFO-5142, requires this change to be merged and published as 1.16.0-SNAPSHOT. The EFX-2 counterpart is TEDEFO-5143.