### PR TITLE
TEDEFO-5143: Add selector-block and SELECT to the EFX-2 grammar

### DIFF
--- a/efx-grammar/Efx.g4
+++ b/efx-grammar/Efx.g4
@@ -48,6 +48,8 @@ options { tokenVocab=EfxLexer;}
 singleExpression
     : StartExpressionBlock context=(FieldId | NodeId | Identifier) (Comma parameterList)? EndBlock expressionBlock EOF   // EFX-1
     | With context=(FieldId | NodeId | Identifier) (Comma parameterList)? Compute expression EOF                         // EFX-2
+    | StartExpressionBlock context=(FieldId | NodeId | Identifier) (Comma parameterList)? EndBlock selectorBlock EOF    // EFX-1 style selector
+    | With context=(FieldId | NodeId | Identifier) (Comma parameterList)? Select selection EOF                          // EFX-2 selector
     ;
 
 /****************************************************************************** 
@@ -70,6 +72,22 @@ standardExpressionBlock
 
 shorthandFieldValueReferenceFromContextField
     : ShorthandFieldValueReferenceFromContextField
+    ;
+
+/*
+ * A selector yields the reference itself rather than its value: the translated selector identifies
+ * the elements rather than reading them. It exists so that a host application can ask EFX where
+ * something is, instead of what it contains.
+ * The reference is resolved exactly as it would be in an expression: relative to the declared
+ * context, unless written as an absolute reference. A selector may only appear at the top level;
+ * it is not an expression and cannot be nested inside one.
+ */
+selectorBlock: StartSelectorBlock selection EndBlock;
+
+selection
+    : fieldContext
+    | nodeContext
+    | attributeReference
     ;
 
 functionInvocation: FunctionPrefix functionName=Identifier OpenParenthesis argumentList? CloseParenthesis;

--- a/efx-grammar/EfxLexer.g4
+++ b/efx-grammar/EfxLexer.g4
@@ -150,6 +150,7 @@ ValueKeyword: 'value';
 ShorthandLabelType: SHARP LabelType -> type(LabelType);
 
 StartExpressionBlock: DOLLAR LBRACE -> pushMode(EXPRESSION);
+StartSelectorBlock: AMPERSAND LBRACE -> pushMode(EXPRESSION);
 StartLabelBlock: SHARP LBRACE -> pushMode(LABEL);
 StartHyperlinkBlock: (TAB | SPACE)* AT LBRACE -> pushMode(EXPRESSION);
 
@@ -327,6 +328,7 @@ By: BY;
 Assert: ASSERT;
 Report: REPORT;
 Compute: COMPUTE;
+Select: SELECT;
 
 // Data types ------------------------------------------------------------------------------------------------
 
@@ -516,6 +518,7 @@ fragment OTHERWISE: ('OTHERWISE' | 'otherwise');
 fragment ASSERT: ('ASSERT' | 'assert');
 fragment REPORT: ('REPORT' | 'report');
 fragment COMPUTE: ('COMPUTE' | 'compute');
+fragment SELECT: ('SELECT' | 'select');
 fragment STAGE: ('STAGE' | 'stage');
 fragment ENDPOINT: ('ENDPOINT' | 'endpoint');
 fragment INDEX: ('INDEX' | 'index');
@@ -529,6 +532,7 @@ fragment RBRACE: '}';
 
 fragment AT: '@';
 fragment DOLLAR: '$';
+fragment AMPERSAND: '&';
 fragment SHARP: '#';
 fragment CHAR_REF: '&' ('#' ([0-9]+ | [xX] [0-9A-Fa-f]+) | [a-zA-Z]+) ';';
 


### PR DESCRIPTION
This pull request adds a selector to the EFX-2 grammar, so that an expression can identify XML elements rather than read their value. It is the EFX-2 counterpart of TEDEFO-5141.

EFX-2 could not express a selector either. A field reference yields the value of the field, and :rawValue yields a text() step, which is the text node rather than the element: an empty element selects nothing, and an attribute selects nothing at all. The rule pathFromReference exists, and admits node references, but is reached only from a presence condition.

A selector may be written in either of two forms, which produce the same result:

    WITH ND-Root SELECT /BT-500-Organization-Company[...]
    {ND-Root} &{/BT-500-Organization-Company[...]}

The second form mirrors the way an expression-block is already accepted alongside COMPUTE, and is the form used in SDK 1.16, so a selector written there remains valid here.

A selector yields the same path that the equivalent expression would use, without the final step that reads the value. It is relative or absolute according to how the reference is written, as elsewhere in the language.

The change is additive. The top-level rule gains two alternatives, and the selection rule, which is identical to the one added to EFX-1, admits a field, node or attribute reference. Two tokens are added to the lexer. No existing rule or token is modified.

The ampersand already opens a character reference in EFX-2 and is therefore excluded from template free text. Since a character reference cannot continue with a brace, the sequence cannot occur in existing content. The SELECT keyword was checked against the identifiers it might shadow: no codelist, attribute name or field alias in the SDK collides with it, and the codelist selection-criterion resolves as an identifier by longest match.

The full EFX Toolkit test suite passes against this grammar.

Support in the toolkit, TEDEFO-5144, requires this change to be merged and published as 2.0.0-SNAPSHOT.